### PR TITLE
Bug Fix -- Undefined Exception class

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,4 +4,10 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/RuleNotFoundException.php
+++ b/src/RuleNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rakit\Validation;
+
+use Exception;
+
+class RuleNotFoundException extends Exception
+{
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -53,7 +53,7 @@ class Validator
     {
         $validator = $this->getValidator($rule);
         if (!$validator) {
-            throw new Exception("Validator '{$rule}' is not registered", 1);
+            throw new RuleNotFoundException("Validator '{$rule}' is not registered", 1);
         }
 
         return clone $validator;

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -143,4 +143,20 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($error_required, 'Kolom email tidak boleh kosong');
     }
 
+    /**
+     * @expectedException \Rakit\Validation\RuleNotFoundException
+     */
+    public function testNonExistentValidationRule()
+    {
+        $validation = $this->validator->make([
+            'name' => "some name"
+        ], [
+            'name' => 'required|xxx'
+        ],[
+            'name.required' => "Fill in your name",
+            'xxx' => "Oops"
+        ]);
+
+        $validation->validate();
+    }
 }


### PR DESCRIPTION
When a non-existent validator is used, an exception is thrown ( https://github.com/rakit/validation/blob/master/src/Validator.php#L56 ) but the exception class doesn't exist in the namespace or anywhere else. That would make `PHP` fail.

I already added tests for this usecase

The change in the phpunit config file is for code coverage, that helped me find untested parts of the library which ultimately fixed the prementioned bug