### PR TITLE
Added new rules

### DIFF
--- a/src/Rules/After.php
+++ b/src/Rules/After.php
@@ -2,27 +2,24 @@
 
 namespace Rakit\Validation\Rules;
 
-use Exception;
 use Rakit\Validation\Rule;
 
 class After extends Rule
 {
 
+    use DateUtils;
+
     public function check($value, array $param)
     {
 
-        if ((strtotime($value) === false) || (strtotime($param[0]) === false)) {
+        if (!$this->isValidDate($value)){
+            throw $this->throwException($value);
+        }
 
-            throw new Exception(
-                "Expected a valid date, got {$value} instead. 2016-12-08, 2016-12-02 14:58, tomorrow are considered valid dates"
-            );
+        if (!$this->isValidDate($param[0])) {
+            throw $this->throwException($param[0]);
         }
 
         return $this->getTimeStamp($param[0]) < $this->getTimeStamp($value);
-    }
-
-    protected function getTimeStamp($date)
-    {
-        return strtotime($date);
     }
 }

--- a/src/Rules/After.php
+++ b/src/Rules/After.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rakit\Validation\Rules;
+
+use Exception;
+use Rakit\Validation\Rule;
+
+class After extends Rule
+{
+
+    public function check($value, array $param)
+    {
+
+        if ((strtotime($value) === false) || (strtotime($param[0]) === false)) {
+
+            throw new Exception(
+                "Expected a valid date, got {$value} instead. 2016-12-08, 2016-12-02 14:58, tomorrow are considered valid dates"
+            );
+        }
+
+        return $this->getTimeStamp($param[0]) < $this->getTimeStamp($value);
+    }
+
+    protected function getTimeStamp($date)
+    {
+        return strtotime($date);
+    }
+}

--- a/src/Rules/Before.php
+++ b/src/Rules/Before.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rakit\Validation\Rules;
+
+use Rakit\Validation\Rule;
+
+class Before extends Rule
+{
+    use DateUtils;
+
+    public function check($value, array $param)
+    {
+
+        if (!$this->isValidDate($value)){
+            throw $this->throwException($value);
+        }
+
+        if (!$this->isValidDate($param[0])) {
+            throw $this->throwException($param[0]);
+        }
+
+        return $this->getTimeStamp($param[0]) > $this->getTimeStamp($value);
+    }
+}

--- a/src/Rules/DateUtils.php
+++ b/src/Rules/DateUtils.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rakit\Validation\Rules;
+
+use Exception;
+
+trait DateUtils
+{
+
+    protected function isValidDate($date)
+    {
+        return (strtotime($date) !== false);
+    }
+
+    protected function throwException($value)
+    {
+        return new Exception(
+            "Expected a valid date, got '{$value}' instead. 2016-12-08, 2016-12-02 14:58, tomorrow are considered valid dates"
+        );
+    }
+
+    protected function getTimeStamp($date)
+    {
+        return strtotime($date);
+    }
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -2,6 +2,9 @@
 
 namespace Rakit\Validation;
 
+use Rakit\Validation\Rules\After;
+use Rakit\Validation\Rules\Before;
+
 class Validator
 {
 
@@ -86,6 +89,8 @@ class Validator
             'present'           => new Rules\Present,
             'different'         => new Rules\Different,
             'uploaded_file'     => new Rules\UploadedFile,
+            'before'            => new Before,
+            'after'             => new After
         ];
 
         foreach($base_validators as $key => $validator) {

--- a/tests/Rules/AfterTest.php
+++ b/tests/Rules/AfterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+
+class AfterTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var \Rakit\Validation\Rules\After
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new \Rakit\Validation\Rules\After();
+    }
+
+    /**
+     * @dataProvider getValidDates
+     */
+    public function testOnlyAWellFormedDateCanBeValidated($date)
+    {
+        $this->assertTrue(
+            $this->validator->check($date, ["3 years ago"])
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidDates
+     * @expectedException Exception
+     */
+    public function testANonWellFormedDateCannotBeValidated($date)
+    {
+        $this->validator->check($date, ["tomorrow"]);
+    }
+
+    public function getInvalidDates()
+    {
+        $now = new DateTime();
+
+        return [
+            [12], //12 instead of 2012
+            ["09"], //like '09 instead of 2009
+            [$now->format("Y m d")],
+            [$now->format("Y m d h:i:s")],
+            ["tommorow"], //typo
+            ["lasst year"] //typo
+        ];
+    }
+
+    public function getValidDates()
+    {
+        $now = new DateTime();
+
+        return [
+            [2016],
+            [$now->format("Y-m-d")],
+            [$now->format("Y-m-d h:i:s")],
+            ["now"],
+            ["tomorrow"],
+            ["2 years ago"]
+        ];
+    }
+
+    public function testProvidedDateFailsValidation()
+    {
+
+        $now = (new DateTime("today"))->format("Y-m-d");
+        $today = "today";
+
+        $this->assertFalse(
+            $this->validator->check($now, ['tomorrow'])
+        );
+
+        $this->assertFalse(
+            $this->validator->check($today, ['tomorrow'])
+        );
+    }
+}

--- a/tests/Rules/AfterTest.php
+++ b/tests/Rules/AfterTest.php
@@ -33,6 +33,14 @@ class AfterTest extends PHPUnit_Framework_TestCase
         $this->validator->check($date, ["tomorrow"]);
     }
 
+    /**
+     * @expectedException Exception
+     */
+    public function testUserProvidedParamCannotBeValidatedBecauseItIsInvalid()
+    {
+        $this->validator->check("now", ["to,morrow"]);
+    }
+
     public function getInvalidDates()
     {
         $now = new DateTime();

--- a/tests/Rules/BeforeTest.php
+++ b/tests/Rules/BeforeTest.php
@@ -1,0 +1,86 @@
+<?php
+
+
+class BeforeTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var \Rakit\Validation\Rules\Before
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new \Rakit\Validation\Rules\Before();
+    }
+
+    /**
+     * @dataProvider getValidDates
+     */
+    public function testOnlyAWellFormedDateCanBeValidated($date)
+    {
+        $this->assertTrue(
+            $this->validator->check($date, ["next week"])
+        );
+    }
+
+    public function getValidDates()
+    {
+        $now = new DateTime();
+
+        return [
+            [2016],
+            [$now->format("Y-m-d")],
+            [$now->format("Y-m-d h:i:s")],
+            ["now"],
+            ["tomorrow"],
+            ["2 years ago"]
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidDates
+     * @expectedException Exception
+     */
+    public function testANonWellFormedDateCannotBeValidated($date)
+    {
+        $this->validator->check($date, ["tomorrow"]);
+    }
+
+    public function getInvalidDates()
+    {
+        $now = new DateTime();
+
+        return [
+            [12], //12 instead of 2012
+            ["09"], //like '09 instead of 2009
+            [$now->format("Y m d")],
+            [$now->format("Y m d h:i:s")],
+            ["tommorow"], //typo
+            ["lasst year"] //typo
+        ];
+    }
+
+    public function testProvidedDateFailsValidation()
+    {
+
+        $now = (new DateTime("today"))->format("Y-m-d");
+        $today = "today";
+
+        $this->assertFalse(
+            $this->validator->check($now, ['yesterday'])
+        );
+
+        $this->assertFalse(
+            $this->validator->check($today, ['yesterday'])
+        );
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testUserProvidedParamCannotBeValidatedBecauseItIsInvalid()
+    {
+        $this->validator->check("now", ["to,morrow"]);
+    }
+}

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -163,7 +163,6 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $validation->validate();
     }
 
-<<<<<<< HEAD
     public function testBeforeRule()
     {
         $data = ["date" => (new DateTime())->format('Y-m-d')];
@@ -204,7 +203,8 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $validator2->validate();
 
         $this->assertFalse($validator2->passes());
-=======
+    }
+        
     public function testNewValidationRuleCanBeAdded()
     {
 
@@ -324,6 +324,5 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull($errors->get('optional_field', 'ipv4'));
         $this->assertNotNull($errors->get('optional_field', 'in'));
         $this->assertNotNull($errors->get('required_if_field', 'email'));
->>>>>>> master
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -159,4 +159,46 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
 
         $validation->validate();
     }
+
+    public function testBeforeRule()
+    {
+        $data = ["date" => (new DateTime())->format('Y-m-d')];
+
+        $validator = $this->validator->make($data, [
+            'date' => 'required|before:tomorrow'
+        ], []);
+
+        $validator->validate();
+
+        $this->assertTrue($validator->passes());
+
+        $validator2 = $this->validator->make($data, [
+            'date' => "required|before:last week"
+        ],[]);
+
+        $validator2->validate();
+
+        $this->assertFalse($validator2->passes());
+    }
+
+    public function testAfterRule()
+    {
+        $data = ["date" => (new DateTime())->format('Y-m-d')];
+
+        $validator = $this->validator->make($data, [
+            'date' => 'required|after:yesterday'
+        ], []);
+
+        $validator->validate();
+
+        $this->assertTrue($validator->passes());
+
+        $validator2 = $this->validator->make($data, [
+            'date' => "required|after:next year"
+        ],[]);
+
+        $validator2->validate();
+
+        $this->assertFalse($validator2->passes());
+    }
 }


### PR DESCRIPTION
I have added two new rules ; `After` and `Before`

```php

$rules = [
   'y' => 'after:tomorrow',
   'z' => 'before:yesterday
]

```

Instead of `tomorrow`, you can also pass in anything that can be converted to a date timestamp by `strtotime`