### PR TITLE
Redefine rule class

### DIFF
--- a/src/MissingRequiredParameterException.php
+++ b/src/MissingRequiredParameterException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rakit\Validation;
+
+class MissingRequiredParameterException extends \Exception
+{
+}

--- a/src/Rules/Accepted.php
+++ b/src/Rules/Accepted.php
@@ -10,7 +10,7 @@ class Accepted extends Rule
 
     protected $message = "The :attribute must be accepted";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         $acceptables = ['yes', 'on', '1', 1, true, 'true'];
         return in_array($value, $acceptables, true);

--- a/src/Rules/After.php
+++ b/src/Rules/After.php
@@ -9,6 +9,8 @@ class After extends Rule
 
     use DateUtils;
 
+    protected $message = "The :attribute must be a date after :time.";
+
     protected $fillable_params = ['time'];
 
     public function check($value)

--- a/src/Rules/After.php
+++ b/src/Rules/After.php
@@ -9,17 +9,21 @@ class After extends Rule
 
     use DateUtils;
 
-    public function check($value, array $param)
+    protected $fillable_params = ['time'];
+
+    public function check($value)
     {
+        $this->requireParameters($this->fillable_params);
+        $time = $this->parameter('time');
 
         if (!$this->isValidDate($value)){
             throw $this->throwException($value);
         }
 
-        if (!$this->isValidDate($param[0])) {
-            throw $this->throwException($param[0]);
+        if (!$this->isValidDate($time)) {
+            throw $this->throwException($time);
         }
 
-        return $this->getTimeStamp($param[0]) < $this->getTimeStamp($value);
+        return $this->getTimeStamp($time) < $this->getTimeStamp($value);
     }
 }

--- a/src/Rules/Alpha.php
+++ b/src/Rules/Alpha.php
@@ -9,7 +9,7 @@ class Alpha extends Rule
 
     protected $message = "The :attribute only allows alphabet characters";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
     }

--- a/src/Rules/AlphaDash.php
+++ b/src/Rules/AlphaDash.php
@@ -9,7 +9,7 @@ class AlphaDash extends Rule
 
     protected $message = "The :attribute only allows a-z, 0-8, _ and -";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         if (! is_string($value) && ! is_numeric($value)) {
             return false;

--- a/src/Rules/AlphaNum.php
+++ b/src/Rules/AlphaNum.php
@@ -9,7 +9,7 @@ class AlphaNum extends Rule
 
     protected $message = "The :attribute only allows alphabet and numeric";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         if (! is_string($value) && ! is_numeric($value)) {
             return false;

--- a/src/Rules/Before.php
+++ b/src/Rules/Before.php
@@ -8,6 +8,8 @@ class Before extends Rule
 {
     use DateUtils;
 
+    protected $message = "The :attribute must be a date before :time.";
+
     protected $fillable_params = ['time'];
 
     public function check($value)

--- a/src/Rules/Before.php
+++ b/src/Rules/Before.php
@@ -8,17 +8,21 @@ class Before extends Rule
 {
     use DateUtils;
 
-    public function check($value, array $param)
+    protected $fillable_params = ['time'];
+
+    public function check($value)
     {
+        $this->requireParameters($this->fillable_params);
+        $time = $this->parameter('time');
 
         if (!$this->isValidDate($value)){
             throw $this->throwException($value);
         }
 
-        if (!$this->isValidDate($param[0])) {
-            throw $this->throwException($param[0]);
+        if (!$this->isValidDate($time)) {
+            throw $this->throwException($time);
         }
 
-        return $this->getTimeStamp($param[0]) > $this->getTimeStamp($value);
+        return $this->getTimeStamp($time) > $this->getTimeStamp($value);
     }
 }

--- a/src/Rules/Between.php
+++ b/src/Rules/Between.php
@@ -7,13 +7,17 @@ use Rakit\Validation\Rule;
 class Between extends Rule
 {
 
-    protected $message = "The :attribute must be between :params[0] and :params[1]";
+    protected $message = "The :attribute must be between :min and :max";
 
-    public function check($value, array $params)
+    protected $fillable_params = ['min', 'max'];
+
+    public function check($value)
     {
-        $this->requireParamsCount($params, 2);
-        $min = (int) $params[0];
-        $max = (int) $params[1];
+        $this->requireParameters($this->fillable_params);
+
+        $min = (int) $this->parameter('min');
+        $max = (int) $this->parameter('max');
+        
         if (is_int($value)) {
             return $value >= $min AND $value <= $max;
         } elseif(is_string($value)) {

--- a/src/Rules/Date.php
+++ b/src/Rules/Date.php
@@ -9,9 +9,17 @@ class Date extends Rule
 
     protected $message = "The :attribute is not valid date format";
 
-    public function check($value, array $params)
+    protected $fillable_params = ['format'];
+
+    protected $params = [
+        'format' => 'Y-m-d'
+    ];
+
+    public function check($value)
     {
-        $format = isset($params[0])? $params[0] : 'Y-m-d';
+        $this->requireParameters($this->fillable_params);
+
+        $format = $this->parameter('format');
         return date_create_from_format($format, $value) !== false;
     }
 

--- a/src/Rules/Different.php
+++ b/src/Rules/Different.php
@@ -7,12 +7,16 @@ use Rakit\Validation\Rule;
 class Different extends Rule
 {
 
-    protected $message = "The :attribute must be different with :params[0]";
+    protected $message = "The :attribute must be different with :field";
 
-    public function check($value, array $params)
+    protected $fillable_params = ['field'];
+
+    public function check($value)
     {
-        $this->requireParamsCount($params, 1);
-        $another_value = $this->validation->getValue($params[0]);
+        $this->requireParameters($this->fillable_params);
+
+        $field = $this->parameter('field');
+        $another_value = $this->validation->getValue($field);
 
         return $value != $another_value;
     }

--- a/src/Rules/Email.php
+++ b/src/Rules/Email.php
@@ -9,7 +9,7 @@ class Email extends Rule
 
     protected $message = "The :attribute is not valid email";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
     }

--- a/src/Rules/In.php
+++ b/src/Rules/In.php
@@ -9,10 +9,21 @@ class In extends Rule
 
     protected $message = "The :attribute is not allowing :value";
 
-    public function check($value, array $params)
+    public function setParameters(array $params)
     {
-        $this->requireParamsCount($params, 1);
-        return in_array($value, $params);
+        if (count($params) == 1 AND is_array($params[0])) {
+            $params = $params[0];
+        }
+        $this->params['allowed_values'] = $params;
+        return $this;
+    }
+
+    public function check($value)
+    {
+        $this->requireParameters(['allowed_values']);
+
+        $allowed_values = $this->parameter('allowed_values');
+        return in_array($value, $allowed_values);
     }
 
 }

--- a/src/Rules/Ip.php
+++ b/src/Rules/Ip.php
@@ -9,7 +9,7 @@ class Ip extends Rule
 
     protected $message = "The :attribute is not valid IP Address";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         return filter_var($value, FILTER_VALIDATE_IP) !== false;
     }

--- a/src/Rules/Ipv4.php
+++ b/src/Rules/Ipv4.php
@@ -9,7 +9,7 @@ class Ipv4 extends Rule
 
     protected $message = "The :attribute is not valid IPv4 Address";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
     }

--- a/src/Rules/Ipv6.php
+++ b/src/Rules/Ipv6.php
@@ -9,7 +9,7 @@ class Ipv6 extends Rule
 
     protected $message = "The :attribute is not valid IPv6 Address";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
     }

--- a/src/Rules/Max.php
+++ b/src/Rules/Max.php
@@ -7,12 +7,15 @@ use Rakit\Validation\Rule;
 class Max extends Rule
 {
 
-    protected $message = "The :attribute maximum is :params[0]";
+    protected $message = "The :attribute maximum is :max";
 
-    public function check($value, array $params)
+    protected $fillable_params = ['max'];
+
+    public function check($value)
     {
-        $this->requireParamsCount($params, 1);
-        $max = (int) $params[0];
+        $this->requireParameters($this->fillable_params);
+
+        $max = (int) $this->parameter('max');
         if (is_int($value)) {
             return $value <= $max;
         } elseif(is_string($value)) {

--- a/src/Rules/Min.php
+++ b/src/Rules/Min.php
@@ -7,12 +7,15 @@ use Rakit\Validation\Rule;
 class Min extends Rule
 {
 
-    protected $message = "The :attribute minimum is :params[0]";
+    protected $message = "The :attribute minimum is :min";
 
-    public function check($value, array $params)
+    protected $fillable_params = ['min'];
+
+    public function check($value)
     {
-        $this->requireParamsCount($params, 1);
-        $min = (int) $params[0];
+        $this->requireParameters($this->fillable_params);
+        
+        $min = (int) $this->parameter('min');
         if (is_int($value)) {
             return $value >= $min;
         } elseif(is_string($value)) {

--- a/src/Rules/NotIn.php
+++ b/src/Rules/NotIn.php
@@ -9,10 +9,20 @@ class NotIn extends Rule
 
     protected $message = "The :attribute is not allowing :value";
 
-    public function check($value, array $params)
+    public function setParameters(array $params)
     {
-        $this->requireParamsCount($params, 1);
-        return !in_array($value, $params);
+        if (count($params) == 1 AND is_array($params[0])) {
+            $params = $params[0];
+        }
+        $this->params['disallowed_values'] = $params;
+        return $this;
+    }
+
+    public function check($value)
+    {
+        $this->requireParameters(['disallowed_values']);
+        $disallowed_values = (array) $this->parameter('disallowed_values');
+        return !in_array($value, $disallowed_values);
     }
 
 }

--- a/src/Rules/Numeric.php
+++ b/src/Rules/Numeric.php
@@ -9,7 +9,7 @@ class Numeric extends Rule
 
     protected $message = "The :attribute must be numeric";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         return is_numeric($value);
     }

--- a/src/Rules/Present.php
+++ b/src/Rules/Present.php
@@ -10,7 +10,7 @@ class Present extends Rule
 
     protected $message = "The :attribute must be present";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         return $this->validation->hasValue($this->attribute->getKey());
     }

--- a/src/Rules/Regex.php
+++ b/src/Rules/Regex.php
@@ -9,10 +9,12 @@ class Regex extends Rule
 
     protected $message = "The :attribute is not valid format";
 
-    public function check($value, array $params)
+    protected $fillable_params = ['regex'];
+
+    public function check($value)
     {
-        $this->requireParamsCount($params, 1);
-        $regex = $params[0];
+        $this->requireParameters($this->fillable_params);
+        $regex = $this->parameter('regex');
         return preg_match($regex, $value) > 0;
     }
 

--- a/src/Rules/Required.php
+++ b/src/Rules/Required.php
@@ -10,7 +10,7 @@ class Required extends Rule
 
     protected $message = "The :attribute is required";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         $this->setAttributeAsRequired();
 

--- a/src/Rules/RequiredIf.php
+++ b/src/Rules/RequiredIf.php
@@ -10,11 +10,19 @@ class RequiredIf extends Required
 
     protected $message = "The :attribute is required";
 
-    public function check($value, array $params)
+    public function setParameters(array $params)
     {
-        $this->requireParamsCount($params, 2);
-        $anotherAttribute = array_shift($params);
-        $definedValues = $params;
+        $this->params['field'] = array_shift($params);
+        $this->params['values'] = $params;
+        return $this;
+    }
+
+    public function check($value)
+    {
+        $this->requireParameters(['field', 'values']);
+
+        $anotherAttribute = $this->parameter('field');
+        $definedValues = $this->parameter('values');
         $anotherValue = $this->validation->getValue($anotherAttribute);
 
         $validator = $this->validation->getValidator();

--- a/src/Rules/Same.php
+++ b/src/Rules/Same.php
@@ -7,12 +7,16 @@ use Rakit\Validation\Rule;
 class Same extends Rule
 {
 
-    protected $message = "The :attribute must be same with :params[0]";
+    protected $message = "The :attribute must be same with :field";
 
-    public function check($value, array $params)
+    protected $fillable_params = ['field'];
+
+    public function check($value)
     {
-        $this->requireParamsCount($params, 1);
-        $anotherValue = $this->validation->getValue($params[0]);
+        $this->requireParameters($this->fillable_params);
+
+        $field = $this->parameter('field');
+        $anotherValue = $this->validation->getValue($field);
 
         return $value == $anotherValue;
     }

--- a/src/Rules/TypeArray.php
+++ b/src/Rules/TypeArray.php
@@ -9,7 +9,7 @@ class TypeArray extends Rule
 
     protected $message = "The :attribute must be array";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         return is_array($value);
     }

--- a/src/Rules/Url.php
+++ b/src/Rules/Url.php
@@ -9,7 +9,7 @@ class Url extends Rule
 
     protected $message = "The :attribute is not valid url";
 
-    public function check($value, array $params)
+    public function check($value)
     {
         return filter_var($value, FILTER_VALIDATE_URL) !== false;
     }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -51,12 +51,18 @@ class Validator
 
     public function __invoke($rule)
     {
+        $args = func_get_args();
+        $rule = array_shift($args);
+        $params = $args;
         $validator = $this->getValidator($rule);
         if (!$validator) {
             throw new RuleNotFoundException("Validator '{$rule}' is not registered", 1);
         }
 
-        return clone $validator;
+        $clonedValidator = clone $validator;
+        $clonedValidator->setParameters($params);
+
+        return $clonedValidator;
     }
 
     protected function registerBaseValidators()

--- a/tests/Fixtures/Json.php
+++ b/tests/Fixtures/Json.php
@@ -6,7 +6,7 @@ class Json extends \Rakit\Validation\Rule
 
     protected $message = "This :attribute is not a valid json object";
 
-    public function check($value, array $params)
+    public function check($value)
     {
 
         json_decode($value);

--- a/tests/Fixtures/Required.php
+++ b/tests/Fixtures/Required.php
@@ -4,7 +4,7 @@
 class Required extends \Rakit\Validation\Rule
 {
 
-    public function check($value, array $params)
+    public function check($value)
     {
         return true;
     }

--- a/tests/Rules/AcceptedTest.php
+++ b/tests/Rules/AcceptedTest.php
@@ -12,20 +12,20 @@ class AcceptedTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('yes', []));
-        $this->assertTrue($this->rule->check('on', []));
-        $this->assertTrue($this->rule->check('1', []));
-        $this->assertTrue($this->rule->check(1, []));
-        $this->assertTrue($this->rule->check(true, []));
-        $this->assertTrue($this->rule->check('true', []));
+        $this->assertTrue($this->rule->check('yes'));
+        $this->assertTrue($this->rule->check('on'));
+        $this->assertTrue($this->rule->check('1'));
+        $this->assertTrue($this->rule->check(1));
+        $this->assertTrue($this->rule->check(true));
+        $this->assertTrue($this->rule->check('true'));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('', []));
-        $this->assertFalse($this->rule->check('onn', []));
-        $this->assertFalse($this->rule->check(' 1', []));
-        $this->assertFalse($this->rule->check(10, []));
+        $this->assertFalse($this->rule->check(''));
+        $this->assertFalse($this->rule->check('onn'));
+        $this->assertFalse($this->rule->check(' 1'));
+        $this->assertFalse($this->rule->check(10));
     }
 
 }

--- a/tests/Rules/AfterTest.php
+++ b/tests/Rules/AfterTest.php
@@ -20,7 +20,7 @@ class AfterTest extends PHPUnit_Framework_TestCase
     public function testOnlyAWellFormedDateCanBeValidated($date)
     {
         $this->assertTrue(
-            $this->validator->check($date, ["3 years ago"])
+            $this->validator->setParameters(["3 years ago"])->check($date)
         );
     }
 
@@ -30,7 +30,7 @@ class AfterTest extends PHPUnit_Framework_TestCase
      */
     public function testANonWellFormedDateCannotBeValidated($date)
     {
-        $this->validator->check($date, ["tomorrow"]);
+        $this->validator->setParameters(["tomorrow"])->check($date);
     }
 
     /**
@@ -38,7 +38,7 @@ class AfterTest extends PHPUnit_Framework_TestCase
      */
     public function testUserProvidedParamCannotBeValidatedBecauseItIsInvalid()
     {
-        $this->validator->check("now", ["to,morrow"]);
+        $this->validator->setParameters(["to,morrow"])->check("now");
     }
 
     public function getInvalidDates()
@@ -76,11 +76,11 @@ class AfterTest extends PHPUnit_Framework_TestCase
         $today = "today";
 
         $this->assertFalse(
-            $this->validator->check($now, ['tomorrow'])
+            $this->validator->setParameters(['tomorrow'])->check($now)
         );
 
         $this->assertFalse(
-            $this->validator->check($today, ['tomorrow'])
+            $this->validator->setParameters(['tomorrow'])->check($today)
         );
     }
 }

--- a/tests/Rules/AlphaDashTest.php
+++ b/tests/Rules/AlphaDashTest.php
@@ -12,18 +12,18 @@ class AlphaDashTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('123', []));
-        $this->assertTrue($this->rule->check('abc', []));
-        $this->assertTrue($this->rule->check('123abc', []));
-        $this->assertTrue($this->rule->check('abc123', []));
-        $this->assertTrue($this->rule->check('foo_123', []));
-        $this->assertTrue($this->rule->check('213-foo', []));
+        $this->assertTrue($this->rule->check('123'));
+        $this->assertTrue($this->rule->check('abc'));
+        $this->assertTrue($this->rule->check('123abc'));
+        $this->assertTrue($this->rule->check('abc123'));
+        $this->assertTrue($this->rule->check('foo_123'));
+        $this->assertTrue($this->rule->check('213-foo'));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('foo bar', []));
-        $this->assertFalse($this->rule->check('123 bar ', []));
+        $this->assertFalse($this->rule->check('foo bar'));
+        $this->assertFalse($this->rule->check('123 bar '));
     }
 
 }

--- a/tests/Rules/AlphaNumTest.php
+++ b/tests/Rules/AlphaNumTest.php
@@ -12,17 +12,17 @@ class AlphaNumTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('123', []));
-        $this->assertTrue($this->rule->check('abc', []));
-        $this->assertTrue($this->rule->check('123abc', []));
-        $this->assertTrue($this->rule->check('abc123', []));
+        $this->assertTrue($this->rule->check('123'));
+        $this->assertTrue($this->rule->check('abc'));
+        $this->assertTrue($this->rule->check('123abc'));
+        $this->assertTrue($this->rule->check('abc123'));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('foo 123', []));
-        $this->assertFalse($this->rule->check('123 foo', []));
-        $this->assertFalse($this->rule->check(' foo123 ', []));
+        $this->assertFalse($this->rule->check('foo 123'));
+        $this->assertFalse($this->rule->check('123 foo'));
+        $this->assertFalse($this->rule->check(' foo123 '));
     }
 
 }

--- a/tests/Rules/AlphaTest.php
+++ b/tests/Rules/AlphaTest.php
@@ -12,19 +12,19 @@ class AlphaTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('foo', []));
-        $this->assertTrue($this->rule->check('foobar', []));
+        $this->assertTrue($this->rule->check('foo'));
+        $this->assertTrue($this->rule->check('foobar'));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check(2, []));
-        $this->assertFalse($this->rule->check([], []));
-        $this->assertFalse($this->rule->check(new stdClass, []));
-        $this->assertFalse($this->rule->check('123asd', []));
-        $this->assertFalse($this->rule->check('asd123', []));
-        $this->assertFalse($this->rule->check('foo123bar', []));
-        $this->assertFalse($this->rule->check('foo bar', []));
+        $this->assertFalse($this->rule->check(2));
+        $this->assertFalse($this->rule->check([]));
+        $this->assertFalse($this->rule->check(new stdClass));
+        $this->assertFalse($this->rule->check('123asd'));
+        $this->assertFalse($this->rule->check('asd123'));
+        $this->assertFalse($this->rule->check('foo123bar'));
+        $this->assertFalse($this->rule->check('foo bar'));
     }
 
 }

--- a/tests/Rules/BeforeTest.php
+++ b/tests/Rules/BeforeTest.php
@@ -20,7 +20,7 @@ class BeforeTest extends PHPUnit_Framework_TestCase
     public function testOnlyAWellFormedDateCanBeValidated($date)
     {
         $this->assertTrue(
-            $this->validator->check($date, ["next week"])
+            $this->validator->setParameters(["next week"])->check($date)
         );
     }
 
@@ -44,7 +44,7 @@ class BeforeTest extends PHPUnit_Framework_TestCase
      */
     public function testANonWellFormedDateCannotBeValidated($date)
     {
-        $this->validator->check($date, ["tomorrow"]);
+        $this->validator->setParameters(["tomorrow"])->check($date);
     }
 
     public function getInvalidDates()
@@ -68,11 +68,11 @@ class BeforeTest extends PHPUnit_Framework_TestCase
         $today = "today";
 
         $this->assertFalse(
-            $this->validator->check($now, ['yesterday'])
+            $this->validator->setParameters(['yesterday'])->check($now)
         );
 
         $this->assertFalse(
-            $this->validator->check($today, ['yesterday'])
+            $this->validator->setParameters(['yesterday'])->check($today)
         );
     }
 
@@ -81,6 +81,6 @@ class BeforeTest extends PHPUnit_Framework_TestCase
      */
     public function testUserProvidedParamCannotBeValidatedBecauseItIsInvalid()
     {
-        $this->validator->check("now", ["to,morrow"]);
+        $this->validator->setParameters(["to,morrow"])->check("now");
     }
 }

--- a/tests/Rules/BetweenTest.php
+++ b/tests/Rules/BetweenTest.php
@@ -12,16 +12,16 @@ class BetweenTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('foobar', [6, 10]));
-        $this->assertTrue($this->rule->check([1,2,3], [2, 3]));
-        $this->assertTrue($this->rule->check(123, [100, 150]));
+        $this->assertTrue($this->rule->setParameters([6, 10])->check('foobar'));
+        $this->assertTrue($this->rule->setParameters([2, 3])->check([1,2,3]));
+        $this->assertTrue($this->rule->setParameters([100, 150])->check(123));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('foobar', [2, 5]));
-        $this->assertFalse($this->rule->check([1,2,3], [4, 6]));
-        $this->assertFalse($this->rule->check(123, [50, 100]));
+        $this->assertFalse($this->rule->setParameters([2, 5])->check('foobar'));
+        $this->assertFalse($this->rule->setParameters([4, 6])->check([1,2,3]));
+        $this->assertFalse($this->rule->setParameters([50, 100])->check(123));
     }
 
 }

--- a/tests/Rules/DateTest.php
+++ b/tests/Rules/DateTest.php
@@ -12,14 +12,14 @@ class DateTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check("2010-10-10", []));
-        $this->assertTrue($this->rule->check("10-10-2010", ['d-m-Y']));
+        $this->assertTrue($this->rule->check("2010-10-10"));
+        $this->assertTrue($this->rule->setParameters(['d-m-Y'])->check("10-10-2010"));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check("10-10-2010", []));
-        $this->assertFalse($this->rule->check("2010-10-10 10:10", ['Y-m-d']));
+        $this->assertFalse($this->rule->check("10-10-2010"));
+        $this->assertFalse($this->rule->setParameters(['Y-m-d'])->check("2010-10-10 10:10"));
     }
 
 }

--- a/tests/Rules/EmailTest.php
+++ b/tests/Rules/EmailTest.php
@@ -12,18 +12,18 @@ class EmailTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('johndoe@gmail.com', []));
-        $this->assertTrue($this->rule->check('johndoe@foo.bar', []));
-        $this->assertTrue($this->rule->check('foo123123@foo.bar.baz', []));
+        $this->assertTrue($this->rule->check('johndoe@gmail.com'));
+        $this->assertTrue($this->rule->check('johndoe@foo.bar'));
+        $this->assertTrue($this->rule->check('foo123123@foo.bar.baz'));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check(1, []));
-        $this->assertFalse($this->rule->check('john doe@gmail.com', []));
-        $this->assertFalse($this->rule->check('johndoe', []));
-        $this->assertFalse($this->rule->check('johndoe.gmail.com', []));
-        $this->assertFalse($this->rule->check('johndoe.gmail.com', []));
+        $this->assertFalse($this->rule->check(1));
+        $this->assertFalse($this->rule->check('john doe@gmail.com'));
+        $this->assertFalse($this->rule->check('johndoe'));
+        $this->assertFalse($this->rule->check('johndoe.gmail.com'));
+        $this->assertFalse($this->rule->check('johndoe.gmail.com'));
     }
 
 }

--- a/tests/Rules/InTest.php
+++ b/tests/Rules/InTest.php
@@ -12,13 +12,13 @@ class InTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check(1, [1,2,3]));
-        $this->assertTrue($this->rule->check('bar', ['1', 'bar', '3']));
+        $this->assertTrue($this->rule->setParameters([1,2,3])->check(1));
+        $this->assertTrue($this->rule->setParameters(['1', 'bar', '3'])->check('bar'));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check(4, [1,2,3]));
+        $this->assertFalse($this->rule->setParameters([1,2,3])->check(4));
     }
 
 }

--- a/tests/Rules/IpTest.php
+++ b/tests/Rules/IpTest.php
@@ -12,18 +12,18 @@ class IpTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('1.2.3.4', []));
-        $this->assertTrue($this->rule->check('255.255.255.255', []));
-        $this->assertTrue($this->rule->check('ff02::2', []));
-        $this->assertTrue($this->rule->check('2001:0000:3238:DFE1:0063:0000:0000:FEFB', []));
+        $this->assertTrue($this->rule->check('1.2.3.4'));
+        $this->assertTrue($this->rule->check('255.255.255.255'));
+        $this->assertTrue($this->rule->check('ff02::2'));
+        $this->assertTrue($this->rule->check('2001:0000:3238:DFE1:0063:0000:0000:FEFB'));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('1.2.3.4.5', []));
-        $this->assertFalse($this->rule->check('256.255.255.255', []));
-        $this->assertFalse($this->rule->check('hf02::2', []));
-        $this->assertFalse($this->rule->check('12345:0000:3238:DFE1:0063:0000:0000:FEFB', []));
+        $this->assertFalse($this->rule->check('1.2.3.4.5'));
+        $this->assertFalse($this->rule->check('256.255.255.255'));
+        $this->assertFalse($this->rule->check('hf02::2'));
+        $this->assertFalse($this->rule->check('12345:0000:3238:DFE1:0063:0000:0000:FEFB'));
     }
 
 }

--- a/tests/Rules/Ipv4Test.php
+++ b/tests/Rules/Ipv4Test.php
@@ -12,15 +12,15 @@ class Ipv4Test extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('0.0.0.0', []));
-        $this->assertTrue($this->rule->check('1.2.3.4', []));
-        $this->assertTrue($this->rule->check('255.255.255.255', []));
+        $this->assertTrue($this->rule->check('0.0.0.0'));
+        $this->assertTrue($this->rule->check('1.2.3.4'));
+        $this->assertTrue($this->rule->check('255.255.255.255'));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('hf02::2', []));
-        $this->assertFalse($this->rule->check('12345:0000:3238:DFE1:0063:0000:0000:FEFB', []));
+        $this->assertFalse($this->rule->check('hf02::2'));
+        $this->assertFalse($this->rule->check('12345:0000:3238:DFE1:0063:0000:0000:FEFB'));
     }
 
 }

--- a/tests/Rules/Ipv6Test.php
+++ b/tests/Rules/Ipv6Test.php
@@ -12,14 +12,14 @@ class Ipv6Test extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('2001:0000:3238:DFE1:0063:0000:0000:FEFB', []));
-        $this->assertTrue($this->rule->check('ff02::2', []));
+        $this->assertTrue($this->rule->check('2001:0000:3238:DFE1:0063:0000:0000:FEFB'));
+        $this->assertTrue($this->rule->check('ff02::2'));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('hf02::2', []));
-        $this->assertFalse($this->rule->check('12345:0000:3238:DFE1:0063:0000:0000:FEFB', []));
+        $this->assertFalse($this->rule->check('hf02::2'));
+        $this->assertFalse($this->rule->check('12345:0000:3238:DFE1:0063:0000:0000:FEFB'));
     }
 
 }

--- a/tests/Rules/MaxTest.php
+++ b/tests/Rules/MaxTest.php
@@ -12,16 +12,16 @@ class MaxTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check(123, [200]));
-        $this->assertTrue($this->rule->check('foobar', [6]));
-        $this->assertTrue($this->rule->check([1,2,3], [3]));
+        $this->assertTrue($this->rule->setParameters([200])->check(123));
+        $this->assertTrue($this->rule->setParameters([6])->check('foobar'));
+        $this->assertTrue($this->rule->setParameters([3])->check([1,2,3]));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('foobar', [5]));
-        $this->assertFalse($this->rule->check([1,2,3], [2]));
-        $this->assertFalse($this->rule->check(123, [100]));
+        $this->assertFalse($this->rule->setParameters([5])->check('foobar'));
+        $this->assertFalse($this->rule->setParameters([2])->check([1,2,3]));
+        $this->assertFalse($this->rule->setParameters([100])->check(123));
     }
 
 }

--- a/tests/Rules/MinTest.php
+++ b/tests/Rules/MinTest.php
@@ -12,16 +12,16 @@ class MinTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check(123, [100]));
-        $this->assertTrue($this->rule->check('foobar', [6]));
-        $this->assertTrue($this->rule->check([1,2,3], [3]));
+        $this->assertTrue($this->rule->setParameters([100])->check(123));
+        $this->assertTrue($this->rule->setParameters([6])->check('foobar'));
+        $this->assertTrue($this->rule->setParameters([3])->check([1,2,3]));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('foobar', [7]));
-        $this->assertFalse($this->rule->check([1,2,3], [4]));
-        $this->assertFalse($this->rule->check(123, [200]));
+        $this->assertFalse($this->rule->setParameters([7])->check('foobar'));
+        $this->assertFalse($this->rule->setParameters([4])->check([1,2,3]));
+        $this->assertFalse($this->rule->setParameters([200])->check(123));
     }
 
 }

--- a/tests/Rules/NotInTest.php
+++ b/tests/Rules/NotInTest.php
@@ -12,13 +12,13 @@ class NotInTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('1', ['2', '3', '4']));
-        $this->assertTrue($this->rule->check(5, [1, 2, 3]));
+        $this->assertTrue($this->rule->setParameters(['2', '3', '4'])->check('1'));
+        $this->assertTrue($this->rule->setParameters([1, 2, 3])->check(5));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('bar', ['bar', 'baz', 'qux']));
+        $this->assertFalse($this->rule->setParameters(['bar', 'baz', 'qux'])->check('bar'));
     }
 
 }

--- a/tests/Rules/NumericTest.php
+++ b/tests/Rules/NumericTest.php
@@ -12,18 +12,18 @@ class NumericTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('123', []));
-        $this->assertTrue($this->rule->check('123.456', []));
-        $this->assertTrue($this->rule->check('-123.456', []));
-        $this->assertTrue($this->rule->check(123, []));
-        $this->assertTrue($this->rule->check(123.456, []));
+        $this->assertTrue($this->rule->check('123'));
+        $this->assertTrue($this->rule->check('123.456'));
+        $this->assertTrue($this->rule->check('-123.456'));
+        $this->assertTrue($this->rule->check(123));
+        $this->assertTrue($this->rule->check(123.456));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('foo123', []));
-        $this->assertFalse($this->rule->check('123foo', []));
-        $this->assertFalse($this->rule->check([123], []));
+        $this->assertFalse($this->rule->check('foo123'));
+        $this->assertFalse($this->rule->check('123foo'));
+        $this->assertFalse($this->rule->check([123]));
     }
 
 }

--- a/tests/Rules/RegexTest.php
+++ b/tests/Rules/RegexTest.php
@@ -12,12 +12,12 @@ class RegexTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check("foo", ["/^F/i"]));
+        $this->assertTrue($this->rule->setParameters(["/^F/i"])->check("foo"));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check("bar", ["/^F/i"]));
+        $this->assertFalse($this->rule->setParameters(["/^F/i"])->check("bar"));
     }
 
 }

--- a/tests/Rules/RequiredTest.php
+++ b/tests/Rules/RequiredTest.php
@@ -12,20 +12,20 @@ class RequiredTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('foo', []));
-        $this->assertTrue($this->rule->check([1], []));
-        $this->assertTrue($this->rule->check(1, []));
-        $this->assertTrue($this->rule->check(true, []));
-        $this->assertTrue($this->rule->check('0', []));
-        $this->assertTrue($this->rule->check(0, []));
-        $this->assertTrue($this->rule->check(new \stdClass, []));
+        $this->assertTrue($this->rule->check('foo'));
+        $this->assertTrue($this->rule->check([1]));
+        $this->assertTrue($this->rule->check(1));
+        $this->assertTrue($this->rule->check(true));
+        $this->assertTrue($this->rule->check('0'));
+        $this->assertTrue($this->rule->check(0));
+        $this->assertTrue($this->rule->check(new \stdClass));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check(null, []));
-        $this->assertFalse($this->rule->check('', []));
-        $this->assertFalse($this->rule->check([], []));
+        $this->assertFalse($this->rule->check(null));
+        $this->assertFalse($this->rule->check(''));
+        $this->assertFalse($this->rule->check([]));
     }
 
 }

--- a/tests/Rules/TypeArrayTest.php
+++ b/tests/Rules/TypeArrayTest.php
@@ -12,15 +12,15 @@ class TypeArrayTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check([], []));
-        $this->assertTrue($this->rule->check([1,2,3], []));
-        $this->assertTrue($this->rule->check([1,2,[4,5,6]], []));
+        $this->assertTrue($this->rule->check([]));
+        $this->assertTrue($this->rule->check([1,2,3]));
+        $this->assertTrue($this->rule->check([1,2,[4,5,6]]));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('[]', []));
-        $this->assertFalse($this->rule->check('[1,2,3]', []));
+        $this->assertFalse($this->rule->check('[]'));
+        $this->assertFalse($this->rule->check('[1,2,3]'));
     }
 
 }

--- a/tests/Rules/UploadedFileTest.php
+++ b/tests/Rules/UploadedFileTest.php
@@ -18,7 +18,7 @@ class UploadedFileTest extends PHPUnit_Framework_TestCase
             'size' => filesize(__FILE__),
             'tmp_name' => __FILE__,
             'error' => 0
-        ], []));
+        ]));
     }
 
     public function testNoUploadedFile()
@@ -29,7 +29,7 @@ class UploadedFileTest extends PHPUnit_Framework_TestCase
             'size' => '',
             'tmp_name' => '',
             'error' => UPLOAD_ERR_NO_FILE
-        ], []));
+        ]));
     }
 
     public function testUploadError()
@@ -40,7 +40,7 @@ class UploadedFileTest extends PHPUnit_Framework_TestCase
             'size' => '',
             'tmp_name' => '',
             'error' => 5
-        ], []));
+        ]));
     }
 
     public function testMaxSize()
@@ -54,7 +54,7 @@ class UploadedFileTest extends PHPUnit_Framework_TestCase
             'size' => 1024*1024*1.1,
             'tmp_name' => __FILE__,
             'error' => 0
-        ], []));
+        ]));
 
         $this->assertTrue($rule->check([
             'name' => pathinfo(__FILE__, PATHINFO_BASENAME),
@@ -62,7 +62,7 @@ class UploadedFileTest extends PHPUnit_Framework_TestCase
             'size' => 1000000,
             'tmp_name' => __FILE__,
             'error' => 0
-        ], []));
+        ]));
     }
 
     public function testMinSize()
@@ -76,7 +76,7 @@ class UploadedFileTest extends PHPUnit_Framework_TestCase
             'size' => 1024, // 1K
             'tmp_name' => __FILE__,
             'error' => 0
-        ], []));
+        ]));
 
         $this->assertTrue($rule->check([
             'name' => pathinfo(__FILE__, PATHINFO_BASENAME),
@@ -84,7 +84,7 @@ class UploadedFileTest extends PHPUnit_Framework_TestCase
             'size' => 10*1024,
             'tmp_name' => __FILE__,
             'error' => 0
-        ], []));
+        ]));
     }
 
 
@@ -99,7 +99,7 @@ class UploadedFileTest extends PHPUnit_Framework_TestCase
             'size' => 1024, // 1K
             'tmp_name' => __FILE__,
             'error' => 0
-        ], []));
+        ]));
 
         $this->assertTrue($rule->check([
             'name' => pathinfo(__FILE__, PATHINFO_BASENAME),
@@ -107,7 +107,7 @@ class UploadedFileTest extends PHPUnit_Framework_TestCase
             'size' => 10*1024,
             'tmp_name' => __FILE__,
             'error' => 0
-        ], []));
+        ]));
 
         $this->assertTrue($rule->check([
             'name' => pathinfo(__FILE__, PATHINFO_BASENAME),
@@ -115,7 +115,7 @@ class UploadedFileTest extends PHPUnit_Framework_TestCase
             'size' => 10*1024,
             'tmp_name' => __FILE__,
             'error' => 0
-        ], []));
+        ]));
     }
 
     public function testInvalids()
@@ -125,27 +125,27 @@ class UploadedFileTest extends PHPUnit_Framework_TestCase
             'size' => filesize(__FILE__),
             'tmp_name' => __FILE__,
             'error' => 0
-        ], []));
+        ]));
 
         $this->assertFalse($this->rule->check([
             'name' => pathinfo(__FILE__, PATHINFO_BASENAME),
             'size' => filesize(__FILE__),
             'tmp_name' => __FILE__,
             'error' => 0
-        ], []));
+        ]));
 
         $this->assertFalse($this->rule->check([
             'name' => pathinfo(__FILE__, PATHINFO_BASENAME),
             'type' => 'text/plain',
             'tmp_name' => __FILE__,
             'error' => 0
-        ], []));
+        ]));
 
         $this->assertFalse($this->rule->check([
             'name' => pathinfo(__FILE__, PATHINFO_BASENAME),
             'type' => 'text/plain',
             'size' => filesize(__FILE__),
-        ], []));
+        ]));
     }
 
 }

--- a/tests/Rules/UrlTest.php
+++ b/tests/Rules/UrlTest.php
@@ -12,15 +12,15 @@ class UrlTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
-        $this->assertTrue($this->rule->check('ftp://foobar.com', []));
-        $this->assertTrue($this->rule->check('http://foobar.com', []));
-        $this->assertTrue($this->rule->check('https://foobar.com', []));
-        $this->assertTrue($this->rule->check('https://foobar.com/path?a=123&b=blah', []));
+        $this->assertTrue($this->rule->check('ftp://foobar.com'));
+        $this->assertTrue($this->rule->check('http://foobar.com'));
+        $this->assertTrue($this->rule->check('https://foobar.com'));
+        $this->assertTrue($this->rule->check('https://foobar.com/path?a=123&b=blah'));
     }
 
     public function testInvalids()
     {
-        $this->assertFalse($this->rule->check('foo:', []));
+        $this->assertFalse($this->rule->check('foo:'));
     }
 
 }


### PR DESCRIPTION
Method `check` no longer accept `$params`. Validation will set rule parameters using `setParameters()` instead passing it to `check()`. 

To set parameters in rule class, you can define `protected $fillabla_params = ['param1', 'param2']` or just override `setParameters` method.

And to get parameters in `check` method, you can use `parameter($key)` method.

For example look at `Rules/Min.php` and `Rules/In.php`.

Then, for validation message, instead using `:params[index]`, we can use more readable format depends on rules like belows:

```php
$validation->setMessages([
    'min' => 'The :attribute must be >= :min',
    'date' => 'The :attribute must be a date formatted as :format',
    'uploaded_file' => 'The :attribute must uploaded file with size between :min_size - :max_size'
]);
```
And now, all built-in rules can be used with invoke ways like belows:

```php
$validation = $validator->validate($inputs, [
    'a_field' => [
        $validator('required')->message('a field is reuqired'),
        $validator('min', 2000)->message('a number must be >= 2000'),
        $validator('max', 5)->message('a number must be <= 5 '),
        $validator('between', 1, 5)->message('a number must be between 1 - 5'),
        $validator('in', [1, 2, 3, 4, 5])->message('etc'),
        $validator('not_in', [1000, 2, 3, 4, 5])->message('etc'),
        $validator('same', 'a_date')->message('etc'),
        $validator('different', 'a_same_number')->message('etc'),
        $validator('date', 'd-m-Y')->message('etc'),
        $validator('uploaded_file', 20000)->message('etc')
    ]
]);
```
