### PR TITLE
Allow turning humanized keys on/off.

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -9,6 +9,8 @@ class Attribute
 
     protected $key;
 
+    protected $humanizedKey;
+
     protected $alias;
 
     protected $validation;
@@ -24,6 +26,7 @@ class Attribute
         $this->validation = $validation;
         $this->alias = $alias;
         $this->key = $key;
+        $this->humanizedKey = ucfirst(str_replace('_', ' ', $key));
         foreach($rules as $rule) {
             $this->addRule($rule);
         }
@@ -92,6 +95,11 @@ class Attribute
     public function getKey()
     {
         return $this->key;
+    }
+
+    public function getHumanizedKey()
+    {
+        return $this->humanizedKey;
     }
 
     public function setAlias($alias)

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -245,8 +245,10 @@ class Validation
             return $this->aliases[$attribute->getKey()];
         } elseif($primaryAttribute AND isset($this->aliases[$primaryAttribute->getKey()])) {
             return $this->aliases[$primaryAttribute->getKey()];
+        } elseif ($this->validator->getUseHumanizedKeys()) {
+            return $attribute->getHumanizedKey();
         } else {
-            return ucfirst(str_replace('_', ' ', $attribute->getKey()));
+            return $attribute->getKey();
         }
     }
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -11,6 +11,8 @@ class Validator
 
     protected $allowRuleOverride = false;
 
+    protected $useHumanizedKeys = true;
+
     public function __construct(array $messages = [])
     {
         $this->messages = $messages;
@@ -123,5 +125,15 @@ class Validator
     public function allowRuleOverride($status = false)
     {
         $this->allowRuleOverride = $status;
+    }
+
+    public function setUseHumanizedKeys($useHumanizedKeys = true)
+    {
+        $this->useHumanizedKeys = $useHumanizedKeys;
+    }
+
+    public function getUseHumanizedKeys()
+    {
+        return $this->useHumanizedKeys;
     }
 }


### PR DESCRIPTION
The formatting of validation messages always replaces`:attribute` with a humanized version of the data key. IE:

```
$data = [
     'user_ids' => [1,2,3]
];

$rules = [
    'user_ids' => 'array'
];
```
When `$data['user_ids']` is not an array the error message is:
```
The User ids must be array
```

----

This PR allows setting humanized keys on/off via:

```
$validator = new \Rakit\Validation\Validator;
$validator->setUseHumanizedKeys(false);
....
```