### PR TITLE
Enhance URL validation by also checking it's scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,25 @@ Value size calculated in same way like `min` and `max` rule.
 #### url
 
 The field under this rule must be valid url format.
+By default it check common URL scheme format like `any_scheme://...`.
+But you can specify URL schemes if you want.
+
+For example:
+
+```php
+$validation = $validator->validate($inputs, [
+    'random_url' => 'url',          // value can be `any_scheme://...`
+    'https_url' => 'url:http',      // value must be started with `https://`
+    'http_url' => 'url:http,https', // value must be started with `http://` or `https://`
+    'ftp_url' => 'url:ftp',         // value must be started with `ftp://`
+    'custom_url' => 'url:custom',   // value must be started with `custom://`
+    'mailto_url' => 'url:mailto',   // value must conatin valid mailto URL scheme like `mailto:a@mail.com,b@mail.com`
+    'jdbc_url' => 'url:jdbc',       // value must contain valid jdbc URL scheme like `jdbc:mysql://localhost/dbname`
+]);
+```
+
+> For commmon URL scheme and mailto, we combine `FILTER_VALIDATE_URL` to validate URL format and `preg_match` to validate it's scheme. 
+  Except for JDBC URL, currently it just check a valid JDBC scheme.
 
 <a id="rule-ip"></a>
 #### ip

--- a/src/Rules/Url.php
+++ b/src/Rules/Url.php
@@ -9,9 +9,64 @@ class Url extends Rule
 
     protected $message = "The :attribute is not valid url";
 
+    public function fillParameters(array $params)
+    {
+        if (count($params) == 1 AND is_array($params[0])) {
+            $params = $params[0];
+        }
+        return $this->forScheme($params);
+    }
+
+    public function forScheme($schemes)
+    {
+        $this->params['schemes'] = (array) $schemes;
+        return $this;
+    }
+
     public function check($value)
     {
+        $schemes = $this->parameter('schemes');
+
+        if (!$schemes) {
+            return $this->validateCommonScheme($value);
+        } else {
+            foreach ($schemes as $scheme) {
+                $method = 'validate' . ucfirst($scheme) .'Scheme';
+                if (method_exists($this, $method)) {
+                    if ($this->{$method}($value)) {
+                        return true;
+                    }
+                } elseif($this->validateCommonScheme($value, $scheme)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public function validateBasic($value)
+    {
         return filter_var($value, FILTER_VALIDATE_URL) !== false;
+    }
+
+    public function validateCommonScheme($value, $scheme = null)
+    {
+        if (!$scheme) {
+            return $this->validateBasic($value) && (bool) preg_match("/^\w+:\/\//i", $value);
+        } else {
+            return $this->validateBasic($value) && (bool) preg_match("/^{$scheme}:\/\//", $value);
+        }
+    }
+
+    public function validateMailtoScheme($value)
+    {
+        return $this->validateBasic($value) && preg_match("/^mailto:/", $value);
+    }
+
+    public function validateJdbcScheme($value)
+    {
+        return (bool) preg_match("/^jdbc:\w+:\/\//", $value);
     }
 
 }

--- a/tests/Rules/UrlTest.php
+++ b/tests/Rules/UrlTest.php
@@ -12,15 +12,40 @@ class UrlTest extends PHPUnit_Framework_TestCase
 
     public function testValids()
     {
+        // Without specific schemes
         $this->assertTrue($this->rule->check('ftp://foobar.com'));
+        $this->assertTrue($this->rule->check('any://foobar.com'));
         $this->assertTrue($this->rule->check('http://foobar.com'));
         $this->assertTrue($this->rule->check('https://foobar.com'));
         $this->assertTrue($this->rule->check('https://foobar.com/path?a=123&b=blah'));
+
+        // Using specific schemes
+        $this->assertTrue($this->rule->fillParameters(['ftp'])->check('ftp://foobar.com'));
+        $this->assertTrue($this->rule->fillParameters(['any'])->check('any://foobar.com'));
+        $this->assertTrue($this->rule->fillParameters(['http'])->check('http://foobar.com'));
+        $this->assertTrue($this->rule->fillParameters(['https'])->check('https://foobar.com'));
+        $this->assertTrue($this->rule->fillParameters(['http', 'https'])->check('https://foobar.com'));
+        $this->assertTrue($this->rule->fillParameters(['foo', 'bar'])->check('bar://foobar.com'));
+        $this->assertTrue($this->rule->fillParameters(['mailto'])->check('mailto:johndoe@gmail.com'));
+        $this->assertTrue($this->rule->fillParameters(['jdbc'])->check('jdbc:mysql://localhost/dbname'));
+
+        // Using forScheme
+        $this->assertTrue($this->rule->forScheme('ftp')->check('ftp://foobar.com'));
+        $this->assertTrue($this->rule->forScheme('http')->check('http://foobar.com'));
+        $this->assertTrue($this->rule->forScheme('https')->check('https://foobar.com'));
+        $this->assertTrue($this->rule->forScheme(['http', 'https'])->check('https://foobar.com'));
+        $this->assertTrue($this->rule->forScheme('mailto')->check('mailto:johndoe@gmail.com'));
+        $this->assertTrue($this->rule->forScheme('jdbc')->check('jdbc:mysql://localhost/dbname'));
     }
 
     public function testInvalids()
     {
         $this->assertFalse($this->rule->check('foo:'));
+        $this->assertFalse($this->rule->check('mailto:johndoe@gmail.com'));
+        $this->assertFalse($this->rule->forScheme('mailto')->check('http://www.foobar.com'));
+        $this->assertFalse($this->rule->forScheme('ftp')->check('http://www.foobar.com'));
+        $this->assertFalse($this->rule->forScheme('jdbc')->check('http://www.foobar.com'));
+        $this->assertFalse($this->rule->forScheme(['http', 'https'])->check('any://www.foobar.com'));
     }
 
 }


### PR DESCRIPTION
As #27 said, `FILTER_VALIDATE_URL` is a minimal URL validation because it didn't validate URL scheme according to [PHP documentation](http://php.net/manual/en/filter.filters.validate.php). So this PR is for adding capability to specifies URL schemes to `url` rule like `url:http`, or `url:http,https`.