### PR TITLE
Add support to get sibling value

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -9,8 +9,6 @@ class Attribute
 
     protected $key;
 
-    protected $humanizedKey;
-
     protected $alias;
 
     protected $validation;
@@ -21,12 +19,13 @@ class Attribute
 
     protected $otherAttributes = [];
 
+    protected $keyIndexes = [];
+
     public function __construct(Validation $validation, $key, $alias = null, array $rules = array())
     {
         $this->validation = $validation;
         $this->alias = $alias;
         $this->key = $key;
-        $this->humanizedKey = ucfirst(str_replace('_', ' ', $key));
         foreach($rules as $rule) {
             $this->addRule($rule);
         }
@@ -35,6 +34,11 @@ class Attribute
     public function setPrimaryAttribute(Attribute $primaryAttribute)
     {
         $this->primaryAttribute = $primaryAttribute;
+    }
+
+    public function setKeyIndexes(array $keyIndexes)
+    {
+        $this->keyIndexes = $keyIndexes;
     }
 
     public function getPrimaryAttribute()
@@ -97,9 +101,28 @@ class Attribute
         return $this->key;
     }
 
+    public function getKeyIndexes()
+    {
+        return $this->keyIndexes;
+    }
+
     public function getHumanizedKey()
     {
-        return $this->humanizedKey;
+        $primaryAttribute = $this->getPrimaryAttribute();
+        $key = str_replace('_', ' ', $this->key);
+
+        // Resolve key from array validation
+        if ($primaryAttribute) {
+            $split = explode('.', $key);
+            $key = implode(' ', array_map(function($word) {
+                if (is_numeric($word)) {
+                    $word = $word + 1;
+                }
+                return Helper::snakeCase($word, ' ');
+            }, $split));
+        }
+
+        return ucfirst($key);
     }
 
     public function setAlias($alias)

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -106,6 +106,36 @@ class Attribute
         return $this->keyIndexes;
     }
 
+    public function getValue($key = null)
+    {
+        if ($key && $this->isArrayAttribute()) {
+            $key = $this->resolveSiblingKey($key);
+        }
+
+        if (!$key) {
+            $key = $this->getKey();
+        }
+
+        return $this->validation->getValue($key);
+    }
+
+    public function isArrayAttribute()
+    {
+        return count($this->getKeyIndexes()) > 0;
+    }
+
+    public function resolveSiblingKey($key)
+    {
+        $indexes = $this->getKeyIndexes();
+        $keys = explode("*", $key);
+        $countAsterisks = count($keys) - 1;
+        if (count($indexes) < $countAsterisks) {
+            $indexes = array_merge($indexes, array_fill(0, $countAsterisks - count($indexes), "*"));
+        }
+        $args = array_merge([str_replace("*", "%s", $key)], $indexes);
+        return call_user_func_array('sprintf', $args);
+    }
+
     public function getHumanizedKey()
     {
         $primaryAttribute = $this->getPrimaryAttribute();

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -158,4 +158,21 @@ class Helper
         return $target;
     }
 
+    /**
+     * Get snake_case format from given string
+     *
+     * @param  string $value
+     * @param  string $delimiter
+     * @return string
+     */
+    public static function snakeCase($value, $delimiter = '_')
+    {
+        if (! ctype_lower($value)) {
+            $value = preg_replace('/\s+/u', '', ucwords($value));
+            $value = strtolower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+        }
+        
+        return $value;
+    }
+
 }

--- a/src/Rules/RequiredIf.php
+++ b/src/Rules/RequiredIf.php
@@ -23,7 +23,7 @@ class RequiredIf extends Required
 
         $anotherAttribute = $this->parameter('field');
         $definedValues = $this->parameter('values');
-        $anotherValue = $this->validation->getValue($anotherAttribute);
+        $anotherValue = $this->getAttribute()->getValue($anotherAttribute);
 
         $validator = $this->validation->getValidator();
         $required_validator = $validator('required');

--- a/src/Rules/RequiredUnless.php
+++ b/src/Rules/RequiredUnless.php
@@ -23,7 +23,7 @@ class RequiredUnless extends Required
 
         $anotherAttribute = $this->parameter('field');
         $definedValues = $this->parameter('values');
-        $anotherValue = $this->validation->getValue($anotherAttribute);
+        $anotherValue = $this->getAttribute()->getValue($anotherAttribute);
 
         $validator = $this->validation->getValidator();
         $required_validator = $validator('required');

--- a/src/Rules/Same.php
+++ b/src/Rules/Same.php
@@ -16,7 +16,7 @@ class Same extends Rule
         $this->requireParameters($this->fillable_params);
 
         $field = $this->parameter('field');
-        $anotherValue = $this->validation->getValue($field);
+        $anotherValue = $this->getAttribute()->getValue($field);
 
         return $value == $anotherValue;
     }

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -117,7 +117,7 @@ class Validation
         $attributeKey = $attribute->getKey();
         $data = Helper::arrayDot($this->initializeAttributeOnData($attributeKey));
 
-        $pattern = str_replace('\*', '[^\.]+', preg_quote($attributeKey));
+        $pattern = str_replace('\*', '([^\.]+)', preg_quote($attributeKey));
 
         $data = array_merge($data, $this->extractValuesForWildcards(
             $data, $attributeKey
@@ -126,9 +126,10 @@ class Validation
         $attributes = [];
 
         foreach ($data as $key => $value) {
-            if ((bool) preg_match('/^'.$pattern.'\z/', $key)) {
+            if ((bool) preg_match('/^'.$pattern.'\z/', $key, $match)) {
                 $attr = new Attribute($this, $key, null, $attribute->getRules());
                 $attr->setPrimaryAttribute($attribute);
+                $attr->setKeyIndexes(array_slice($match, 1));
                 $attributes[] = $attr;
             }
         }
@@ -304,6 +305,7 @@ class Validation
             }
         }
 
+        // Replace message params
         $vars = array_merge($params, [
             'attribute' => $alias,
             'value' => $value,
@@ -312,6 +314,20 @@ class Validation
         foreach($vars as $key => $value) {
             $value = $this->stringify($value);
             $message = str_replace(':'.$key, $value, $message);
+        }
+
+        // Replace key indexes
+        $keyIndexes = $attribute->getKeyIndexes();
+        foreach ($keyIndexes as $pathIndex => $index) {
+            $replacers = [
+                "[{$pathIndex}]" => $index,
+            ];
+
+            if (is_numeric($index)) {
+                $replacers["{{$pathIndex}}"] = $index + 1;
+            }
+
+            $message = str_replace(array_keys($replacers), array_values($replacers), $message);
         }
 
         return $message;

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -73,6 +73,8 @@ class Validation
 
         $attributeKey = $attribute->getKey();
         $rules = $attribute->getRules(); 
+
+
         $value = $this->getValue($attributeKey);
         $isEmptyValue = $this->isEmptyValue($value);
 
@@ -84,11 +86,11 @@ class Validation
                 continue;
             }
 
+            $valid = $ruleValidator->check($value);
+
             if ($isEmptyValue AND $this->ruleIsOptional($attribute, $ruleValidator)) {
                 continue;
             }
-
-            $valid = $ruleValidator->check($value);
             
             if (!$valid) {
                 $isValid = false;

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -74,12 +74,13 @@ class Validation
         $attributeKey = $attribute->getKey();
         $rules = $attribute->getRules(); 
 
-
         $value = $this->getValue($attributeKey);
         $isEmptyValue = $this->isEmptyValue($value);
 
         $isValid = true;
         foreach($rules as $ruleValidator) {
+            $ruleValidator->setAttribute($attribute);
+
             if ($isEmptyValue && $ruleValidator instanceof Defaults) {
                 $value = $ruleValidator->check(null);
                 $isEmptyValue = $this->isEmptyValue($value);

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -876,4 +876,28 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull($errors->first('products.14.notes'));
     }
 
+    public function testSameRuleOnArrayAttribute()
+    {
+        $validation = $this->validator->validate([
+            'users' => [
+                [
+                    'password' => 'foo',
+                    'password_confirmation' => 'foo'
+                ],
+                [
+                    'password' => 'foo',
+                    'password_confirmation' => 'bar'
+                ],
+            ]
+        ], [
+            'users.*.password_confirmation' => 'required|same:users.*.password',
+        ]);
+
+        $this->assertFalse($validation->passes());
+
+        $errors = $validation->errors();
+        $this->assertNull($errors->first('users.0.password_confirmation:same'));
+        $this->assertNotNull($errors->first('users.1.password_confirmation:same'));
+    }
+
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -842,4 +842,38 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertNull($errors->first('products.14.notes'));
     }
 
+    public function testRequiredUnlessOnArrayAttribute()
+    {
+        $validation = $this->validator->validate([
+            'products' => [
+                // valid because has_notes is 1
+                '10' => [
+                    'quantity' => 8,
+                    'has_notes' => 1,
+                    'notes' => ''
+                ],
+                // invalid because has_notes is not 1
+                '12' => [
+                    'quantity' => 0,
+                    'has_notes' => null,
+                    'notes' => ''
+                ],
+                // invalid because no has_notes
+                '14' => [
+                    'quantity' => 0,
+                    'notes' => ''
+                ],
+            ]
+        ], [
+            'products.*.notes' => 'required_unless:products.*.has_notes,1',
+        ]);
+
+        $this->assertFalse($validation->passes());
+
+        $errors = $validation->errors();
+        $this->assertNull($errors->first('products.10.notes'));
+        $this->assertNotNull($errors->first('products.12.notes'));
+        $this->assertNotNull($errors->first('products.14.notes'));
+    }
+
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -808,4 +808,38 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($errors->first('cart.*.attributes.*.value'), 'Item 2 attribute 1 value is required');
     }
 
+    public function testRequiredIfOnArrayAttribute()
+    {
+        $validation = $this->validator->validate([
+            'products' => [
+                // invalid because has_notes is not empty
+                '10' => [
+                    'quantity' => 8,
+                    'has_notes' => 1,
+                    'notes' => ''
+                ],
+                // valid because has_notes is null
+                '12' => [
+                    'quantity' => 0,
+                    'has_notes' => null,
+                    'notes' => ''
+                ],
+                // valid because no has_notes
+                '14' => [
+                    'quantity' => 0,
+                    'notes' => ''
+                ],
+            ]
+        ], [
+            'products.*.notes' => 'required_if:products.*.has_notes,1',
+        ]);
+
+        $this->assertFalse($validation->passes());
+
+        $errors = $validation->errors();
+        $this->assertNotNull($errors->first('products.10.notes'));
+        $this->assertNull($errors->first('products.12.notes'));
+        $this->assertNull($errors->first('products.14.notes'));
+    }
+
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -749,4 +749,63 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
             'is_published' => 'invalid-value',
         ]);
     }
+
+    public function testHumanizedKeyInArrayValidation()
+    {
+        $validation = $this->validator->validate([
+            'cart' => [
+                [
+                    'qty' => 'xyz',
+                ],
+            ]
+        ], [
+            'cart.*.itemName' => 'required',
+            'cart.*.qty' => 'required|numeric'
+        ]);
+
+        $errors = $validation->errors();
+
+        $this->assertEquals($errors->first('cart.*.qty'), 'The Cart 1 qty must be numeric');
+        $this->assertEquals($errors->first('cart.*.itemName'), 'The Cart 1 item name is required');
+    }
+
+    public function testCustomMessageInArrayValidation()
+    {
+        $validation = $this->validator->make([
+            'cart' => [
+                [
+                    'qty' => 'xyz',
+                    'itemName' => 'Lorem ipsum'
+                ],
+                [
+                    'qty' => 10,
+                    'attributes' => [
+                        [
+                            'name' => 'color',
+                            'value' => null
+                        ]
+                    ]
+                ],
+            ]
+        ], [
+            'cart.*.itemName' => 'required',
+            'cart.*.qty' => 'required|numeric',
+            'cart.*.attributes.*.value' => 'required'
+        ]);
+
+        $validation->setMessages([
+            'cart.*.itemName:required' => 'Item [0] name is required',
+            'cart.*.qty:numeric' => 'Item {0} qty is not a number',
+            'cart.*.attributes.*.value' => 'Item {0} attribute {1} value is required',
+        ]);
+
+        $validation->validate();
+
+        $errors = $validation->errors();
+
+        $this->assertEquals($errors->first('cart.*.qty'), 'Item 1 qty is not a number');
+        $this->assertEquals($errors->first('cart.*.itemName'), 'Item 1 name is required');
+        $this->assertEquals($errors->first('cart.*.attributes.*.value'), 'Item 2 attribute 1 value is required');
+    }
+
 }


### PR DESCRIPTION
Add method to get sibling value (for array attribute) and use that method in some rules that need other field values such as `required_if`, `required_unless`, and `same`.