### PR TITLE
Add method to enable strict checking for rule 'in' and 'not_in'

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,10 +417,28 @@ The field under this rule may have alpha-numeric characters, as well as dashes a
 
 The field under this rule must be included in the given list of values.
 
+This rule is using `in_array` to check the value. 
+By default `in_array` disable strict checking. 
+So it doesn't check data type.
+If you want enable strict checking, you can invoke validator like this:
+
+```php
+$validation = $validator->validate($data, [
+    'enabled' => [
+        'required', 
+        $validator('in', [true, 1])->strict()
+    ]
+]);
+```
+
+Then 'enabled' value should be boolean `true`, or int `1`.
+
 <a id="rule-not_in"></a>
 #### not_in:value_1,value_2,...
 
 The field under this rule must not be included in the given list of values.
+
+This rule also using `in_array`. You can enable strict checking by invoking validator and call `strict()` like example in rule `in` above.
 
 <a id="rule-min"></a>
 #### min:number

--- a/src/Rules/In.php
+++ b/src/Rules/In.php
@@ -9,6 +9,8 @@ class In extends Rule
 
     protected $message = "The :attribute is not allowing :value";
 
+    protected $strict = false;
+
     public function fillParameters(array $params)
     {
         if (count($params) == 1 AND is_array($params[0])) {
@@ -18,12 +20,17 @@ class In extends Rule
         return $this;
     }
 
+    public function strict($strict = true)
+    {
+        $this->strict = $strict;
+    }
+
     public function check($value)
     {
         $this->requireParameters(['allowed_values']);
 
         $allowed_values = $this->parameter('allowed_values');
-        return in_array($value, $allowed_values);
+        return in_array($value, $allowed_values, $this->strict);
     }
 
 }

--- a/src/Rules/NotIn.php
+++ b/src/Rules/NotIn.php
@@ -9,6 +9,8 @@ class NotIn extends Rule
 
     protected $message = "The :attribute is not allowing :value";
 
+    protected $strict = false;
+
     public function fillParameters(array $params)
     {
         if (count($params) == 1 AND is_array($params[0])) {
@@ -18,11 +20,16 @@ class NotIn extends Rule
         return $this;
     }
 
+    public function strict($strict = true)
+    {
+        $this->strict = $strict;
+    }
+
     public function check($value)
     {
         $this->requireParameters(['disallowed_values']);
         $disallowed_values = (array) $this->parameter('disallowed_values');
-        return !in_array($value, $disallowed_values);
+        return !in_array($value, $disallowed_values, $this->strict);
     }
 
 }

--- a/tests/Rules/InTest.php
+++ b/tests/Rules/InTest.php
@@ -21,4 +21,16 @@ class InTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($this->rule->fillParameters([1,2,3])->check(4));
     }
 
+    public function testStricts()
+    {
+        // Not strict
+        $this->assertTrue($this->rule->fillParameters(['1', '2', '3'])->check(1));        
+        $this->assertTrue($this->rule->fillParameters(['1', '2', '3'])->check(true));
+
+        // Strict        
+        $this->rule->strict();
+        $this->assertFalse($this->rule->fillParameters(['1', '2', '3'])->check(1));        
+        $this->assertFalse($this->rule->fillParameters(['1', '2', '3'])->check(1));        
+    }
+
 }

--- a/tests/Rules/NotInTest.php
+++ b/tests/Rules/NotInTest.php
@@ -21,4 +21,16 @@ class NotInTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($this->rule->fillParameters(['bar', 'baz', 'qux'])->check('bar'));
     }
 
+    public function testStricts()
+    {
+        // Not strict
+        $this->assertFalse($this->rule->fillParameters(['1', '2', '3'])->check(1));        
+        $this->assertFalse($this->rule->fillParameters(['1', '2', '3'])->check(true));
+
+        // Strict        
+        $this->rule->strict();
+        $this->assertTrue($this->rule->fillParameters(['1', '2', '3'])->check(1));        
+        $this->assertTrue($this->rule->fillParameters(['1', '2', '3'])->check(1));        
+    }
+
 }


### PR DESCRIPTION
Rule `in` and `not_in` is using `in_array` function. By default `in_array` disabling strict checking in it's [3rd parameter](http://php.net/manual/en/function.in-array.php). So I just add method to enable strict checking for those rules.