### PR TITLE
Fixing min and max rule for string type

### DIFF
--- a/src/Rules/Max.php
+++ b/src/Rules/Max.php
@@ -19,7 +19,7 @@ class Max extends Rule
         if (is_int($value)) {
             return $value <= $max;
         } elseif(is_string($value)) {
-            return mb_strlen($value) <= $max;
+            return mb_strlen($value, 'UTF-8') <= $max;
         } elseif(is_array($value)) {
             return count($value) <= $max;
         } else {

--- a/src/Rules/Max.php
+++ b/src/Rules/Max.php
@@ -19,7 +19,7 @@ class Max extends Rule
         if (is_int($value)) {
             return $value <= $max;
         } elseif(is_string($value)) {
-            return strlen($value) <= $max;
+            return mb_strlen($value) <= $max;
         } elseif(is_array($value)) {
             return count($value) <= $max;
         } else {

--- a/src/Rules/Min.php
+++ b/src/Rules/Min.php
@@ -19,7 +19,7 @@ class Min extends Rule
         if (is_int($value)) {
             return $value >= $min;
         } elseif(is_string($value)) {
-            return strlen($value) >= $min;
+            return mb_strlen($value) >= $min;
         } elseif(is_array($value)) {
             return count($value) >= $min;
         } else {

--- a/src/Rules/Min.php
+++ b/src/Rules/Min.php
@@ -19,7 +19,7 @@ class Min extends Rule
         if (is_int($value)) {
             return $value >= $min;
         } elseif(is_string($value)) {
-            return mb_strlen($value) >= $min;
+            return mb_strlen($value, 'UTF-8') >= $min;
         } elseif(is_array($value)) {
             return count($value) >= $min;
         } else {

--- a/tests/Rules/MaxTest.php
+++ b/tests/Rules/MaxTest.php
@@ -15,6 +15,11 @@ class MaxTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->rule->fillParameters([200])->check(123));
         $this->assertTrue($this->rule->fillParameters([6])->check('foobar'));
         $this->assertTrue($this->rule->fillParameters([3])->check([1,2,3]));
+
+        $this->assertTrue($this->rule->fillParameters([3])->check('мин'));
+        $this->assertTrue($this->rule->fillParameters([4])->check('كلمة'));
+        $this->assertTrue($this->rule->fillParameters([3])->check('ワード'));
+        $this->assertTrue($this->rule->fillParameters([1])->check('字'));
     }
 
     public function testInvalids()

--- a/tests/Rules/MinTest.php
+++ b/tests/Rules/MinTest.php
@@ -21,7 +21,12 @@ class MinTest extends PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->rule->fillParameters([7])->check('foobar'));
         $this->assertFalse($this->rule->fillParameters([4])->check([1,2,3]));
-        $this->assertFalse($this->rule->fillParameters([200])->check(123));
+        $this->assertFalse($this->rule->fillParameters([200])->check(123));  
+
+        $this->assertFalse($this->rule->fillParameters([4])->check('мин'));
+        $this->assertFalse($this->rule->fillParameters([5])->check('كلمة'));
+        $this->assertFalse($this->rule->fillParameters([4])->check('ワード'));
+        $this->assertFalse($this->rule->fillParameters([2])->check('字'));      
     }
 
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -909,10 +909,16 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
                     'qty' => 'invalid'
                 ]
             ],
+            'emails' => [
+                'foo@bar.com',
+                'something',
+                'foo@blah.com'
+            ],
             'thing' => 'exists',
         ], [
             'thing' => 'required',
             'items.*.product_id' => 'required|numeric',
+            'emails.*' => 'required|email',
             'items.*.qty' => 'required|numeric',
             'something' => 'default:on|required|in:on,off'
         ]);
@@ -924,6 +930,10 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
                 [
                     'product_id' => 1
                 ]
+            ],
+            'emails' => [
+                0 => 'foo@bar.com',
+                2 => 'foo@blah.com'
             ],
             'thing' => 'exists',
             'something' => 'on'
@@ -939,10 +949,16 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
                     'qty' => 'invalid'
                 ]
             ],
+            'emails' => [
+                'foo@bar.com',
+                'something',
+                'foo@blah.com'
+            ],
             'thing' => 'exists',
         ], [
             'thing' => 'required',
             'items.*.product_id' => 'required|numeric',
+            'emails.*' => 'required|email',
             'items.*.qty' => 'required|numeric',
             'something' => 'required|in:on,off'
         ]);
@@ -954,6 +970,9 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
                 [
                     'qty' => 'invalid'
                 ]
+            ],
+            'emails' => [
+                1 => 'something'
             ],
             'something' => null
         ], $invalidData);


### PR DESCRIPTION
Replace `strlen` with `mb_strlen` to gives correct string length as suggested by @DenislavParvanov at #48 