### PR TITLE
Add digits and digits_between rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ Below is list of all available validation rules
 * [min](#rule-min)
 * [max](#rule-max)
 * [between](#rule-between)
+* [digits](#rule-digits)
+* [digits_between](#rule-digits_between)
 * [url](#rule-url)
 * [ip](#rule-ip)
 * [ipv4](#rule-ipv4)
@@ -476,6 +478,16 @@ Value size calculated in same way like `min` rule.
 
 The field under this rule must have a size between min and max params. 
 Value size calculated in same way like `min` and `max` rule.
+
+<a id="rule-digits"></a>
+#### digits:value
+
+The field under validation must be numeric and must have an exact length of `value`.
+
+<a id="rule-digits_between"></a>
+#### digits_between:min,max
+
+The field under validation must have a length between the given `min` and `max`.
 
 <a id="rule-url"></a>
 #### url

--- a/src/Rules/Digits.php
+++ b/src/Rules/Digits.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rakit\Validation\Rules;
+
+use Rakit\Validation\Rule;
+
+class Digits extends Rule
+{
+
+    protected $message = "The :attribute must be numeric and must have an exact length of :length";
+
+    protected $fillable_params = ['length'];
+
+    public function check($value)
+    {
+    	$this->requireParameters($this->fillable_params);
+
+        $length = (int) $this->parameter('length');
+
+        return ! preg_match('/[^0-9]/', $value)
+                    && strlen((string) $value) == $length;
+    }
+
+}

--- a/src/Rules/DigitsBetween.php
+++ b/src/Rules/DigitsBetween.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rakit\Validation\Rules;
+
+use Rakit\Validation\Rule;
+
+class DigitsBetween extends Rule
+{
+
+    protected $message = "The :attribute must have a length between the given :min and :max";
+
+    protected $fillable_params = ['min', 'max'];
+
+    public function check($value)
+    {
+    	$this->requireParameters($this->fillable_params);
+
+        $min = (int) $this->parameter('min');
+        $max = (int) $this->parameter('max');
+
+        $length = strlen((string) $value);
+
+        return ! preg_match('/[^0-9]/', $value)
+                    && $length >= $min && $length <= $max;
+    }
+
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -107,6 +107,7 @@ class Validator
             'lowercase'                 => new Rules\Lowercase,
             'uppercase'                 => new Rules\Uppercase,
             'json'                      => new Rules\Json,
+            'digits'                      => new Rules\Digits,
             'defaults'                  => new Rules\Defaults,
             'default'                   => new Rules\Defaults, // alias of defaults
         ];

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -107,7 +107,8 @@ class Validator
             'lowercase'                 => new Rules\Lowercase,
             'uppercase'                 => new Rules\Uppercase,
             'json'                      => new Rules\Json,
-            'digits'                      => new Rules\Digits,
+            'digits'                    => new Rules\Digits,
+            'digits_between'            => new Rules\DigitsBetween,
             'defaults'                  => new Rules\Defaults,
             'default'                   => new Rules\Defaults, // alias of defaults
         ];

--- a/tests/Rules/DigitsBetweenTest.php
+++ b/tests/Rules/DigitsBetweenTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Rakit\Validation\Rules\DigitsBetween;
+
+class DigitsBetweenTest extends PHPUnit_Framework_TestCase
+{
+
+    public function setUp()
+    {
+        $this->rule = new DigitsBetween;
+    }
+
+    public function testValids()
+    {
+        $this->assertTrue($this->rule->fillParameters([2, 6])->check(12345));
+        $this->assertTrue($this->rule->fillParameters([2, 3])->check(12));
+        $this->assertTrue($this->rule->fillParameters([2, 3])->check(123));
+        $this->assertTrue($this->rule->fillParameters([3, 5])->check('12345'));
+    }
+
+    public function testInvalids()
+    {
+        $this->assertFalse($this->rule->fillParameters([4, 6])->check(12));
+        $this->assertFalse($this->rule->fillParameters([1, 3])->check(12345));
+        $this->assertFalse($this->rule->fillParameters([1, 3])->check(12345));
+        $this->assertFalse($this->rule->fillParameters([3, 6])->check('foobar'));
+    }
+
+}

--- a/tests/Rules/DigitsTest.php
+++ b/tests/Rules/DigitsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Rakit\Validation\Rules\Digits;
+
+class DigitsTest extends PHPUnit_Framework_TestCase
+{
+
+    public function setUp()
+    {
+        $this->rule = new Digits;
+    }
+
+    public function testValids()
+    {
+        $this->assertTrue($this->rule->fillParameters([4])->check(1243));
+        $this->assertTrue($this->rule->fillParameters([6])->check(124567));
+        $this->assertTrue($this->rule->fillParameters([3])->check('123'));
+    }
+
+    public function testInvalids()
+    {
+        $this->assertFalse($this->rule->fillParameters([7])->check(12345678));
+        $this->assertFalse($this->rule->fillParameters([4])->check(12));      
+        $this->assertFalse($this->rule->fillParameters([3])->check('foo'));      
+    }
+
+}


### PR DESCRIPTION
I recently check on Laravel validation rule and see digits and digits_between.
digits_between look really similar to between but in a different approach. 

digits_between check the given length 
between check the given value