### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
-  - composer self-update
-  - composer install --dev
+  - composer install
 
 script: phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,16 @@
       "Rakit\\Validation\\": "src"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Rakit\\Validation\\Tests\\": ["tests", "tests/Fixtures"]
+    }
+  },
   "require": {
-    "php": ">=5.5.0",
+    "php": ">=7.0",
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.*"
+    "phpunit/phpunit": "^6.5"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,22 @@
-<phpunit bootstrap="vendor/autoload.php">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+>
     <testsuites>
-        <testsuite name="Block">
+        <testsuite name="Validation test suites">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-
     <filter>
         <whitelist>
-            <directory>./src</directory>
+            <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -92,7 +92,7 @@ abstract class Rule
     {
         $this->message = $message;
         return $this;
-    }    
+    }
 
     public function getMessage()
     {

--- a/src/Rules/Defaults.php
+++ b/src/Rules/Defaults.php
@@ -14,7 +14,7 @@ class Defaults extends Rule
     public function check($value)
     {
         $this->requireParameters($this->fillable_params);
-        
+
         $default = $this->parameter('default');
         return $default;
     }

--- a/src/Rules/Json.php
+++ b/src/Rules/Json.php
@@ -14,7 +14,7 @@ class Json extends Rule
         if (! is_string($value) || empty($value)) {
             return false;
         }
-        
+
         json_decode($value);
 
         if (json_last_error() !== JSON_ERROR_NONE) {

--- a/src/Rules/Min.php
+++ b/src/Rules/Min.php
@@ -14,7 +14,7 @@ class Min extends Rule
     public function check($value)
     {
         $this->requireParameters($this->fillable_params);
-        
+
         $min = (int) $this->parameter('min');
         if (is_int($value)) {
             return $value >= $min;

--- a/src/Rules/RequiredIf.php
+++ b/src/Rules/RequiredIf.php
@@ -30,7 +30,7 @@ class RequiredIf extends Required
 
         if (in_array($anotherValue, $definedValues)) {
             $this->setAttributeAsRequired();
-            return $required_validator->check($value, []); 
+            return $required_validator->check($value, []);
         }
 
         return true;

--- a/src/Rules/RequiredUnless.php
+++ b/src/Rules/RequiredUnless.php
@@ -30,7 +30,7 @@ class RequiredUnless extends Required
 
         if (!in_array($anotherValue, $definedValues)) {
             $this->setAttributeAsRequired();
-            return $required_validator->check($value, []); 
+            return $required_validator->check($value, []);
         }
 
         return true;

--- a/src/Rules/RequiredWith.php
+++ b/src/Rules/RequiredWith.php
@@ -26,7 +26,7 @@ class RequiredWith extends Required
         foreach($fields as $field) {
             if ($this->validation->hasValue($field)) {
                 $this->setAttributeAsRequired();
-                return $required_validator->check($value, []); 
+                return $required_validator->check($value, []);
             }
         }
 

--- a/src/Rules/RequiredWithAll.php
+++ b/src/Rules/RequiredWithAll.php
@@ -30,7 +30,7 @@ class RequiredWithAll extends Required
         }
 
         $this->setAttributeAsRequired();
-        return $required_validator->check($value, []); 
+        return $required_validator->check($value, []);
     }
 
 }

--- a/src/Rules/RequiredWithout.php
+++ b/src/Rules/RequiredWithout.php
@@ -26,7 +26,7 @@ class RequiredWithout extends Required
         foreach($fields as $field) {
             if (!$this->validation->hasValue($field)) {
                 $this->setAttributeAsRequired();
-                return $required_validator->check($value, []); 
+                return $required_validator->check($value, []);
             }
         }
 

--- a/src/Rules/RequiredWithoutAll.php
+++ b/src/Rules/RequiredWithoutAll.php
@@ -30,7 +30,7 @@ class RequiredWithoutAll extends Required
         }
 
         $this->setAttributeAsRequired();
-        return $required_validator->check($value, []); 
+        return $required_validator->check($value, []);
     }
 
 }

--- a/src/Rules/UploadedFile.php
+++ b/src/Rules/UploadedFile.php
@@ -56,7 +56,7 @@ class UploadedFile extends Rule
     }
 
     public function check($value)
-    {   
+    {
         $minSize = $this->parameter('min_size');
         $maxSize = $this->parameter('max_size');
         $allowedTypes = $this->parameter('allowed_types');

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -50,7 +50,7 @@ class Validator
     public function make(array $inputs, array $rules, array $messages = array())
     {
         $messages = array_merge($this->messages, $messages);
-        return new Validation($this, $inputs, $rules, $messages); 
+        return new Validation($this, $inputs, $rules, $messages);
     }
 
     public function __invoke($rule)

--- a/tests/ErrorBagTest.php
+++ b/tests/ErrorBagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\ErrorBag;
+namespace Rakit\Validation\Tests;
 
-class ErrorBagTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\ErrorBag;
+use PHPUnit\Framework\TestCase;
+
+class ErrorBagTest extends TestCase
 {
 
     public function testCount()
@@ -117,7 +120,7 @@ class ErrorBagTest extends PHPUnit_Framework_TestCase
                 'email' => '1',
                 'unique' => '2',
             ],
-            
+
             'items.0.id_product' => [
                 'numeric' => '3',
                 'etc' => 'x'
@@ -125,7 +128,7 @@ class ErrorBagTest extends PHPUnit_Framework_TestCase
             'items.0.qty' => [
                 'numeric' => 'a'
             ],
-            
+
             'items.1.id_product' => [
                 'numeric' => '4',
                 'etc' => 'y'
@@ -227,7 +230,7 @@ class ErrorBagTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($errors->all('prefix :message suffix'), [
             'prefix 1 suffix',
             'prefix 2 suffix',
-            
+
             'prefix 3 suffix',
             'prefix x suffix',
             'prefix a suffix',
@@ -263,7 +266,7 @@ class ErrorBagTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($errors->firstOfAll('prefix :message suffix'), [
             'prefix 1 suffix',
-            
+
             'prefix 3 suffix',
             'prefix a suffix',
 

--- a/tests/Fixtures/Even.php
+++ b/tests/Fixtures/Even.php
@@ -1,7 +1,10 @@
 <?php
 
+namespace Rakit\Validation\Tests;
 
-class Even extends \Rakit\Validation\Rule
+use Rakit\Validation\Rule;
+
+class Even extends Rule
 {
 
     protected $message = "The :attribute must be even";

--- a/tests/Fixtures/Required.php
+++ b/tests/Fixtures/Required.php
@@ -1,7 +1,10 @@
 <?php
 
+namespace Rakit\Validation\Tests;
 
-class Required extends \Rakit\Validation\Rule
+use Rakit\Validation\Rule;
+
+class Required extends Rule
 {
 
     public function check($value)

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Helper;
+namespace Rakit\Validation\Tests;
 
-class HelperTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Helper;
+use PHPUnit\Framework\TestCase;
+
+class HelperTest extends TestCase
 {
 
     public function testArrayHas()

--- a/tests/Rules/AcceptedTest.php
+++ b/tests/Rules/AcceptedTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Accepted;
+namespace Rakit\Validation\Tests;
 
-class AcceptedTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Accepted;
+use PHPUnit\Framework\TestCase;
+
+class AcceptedTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/AfterTest.php
+++ b/tests/Rules/AfterTest.php
@@ -1,7 +1,12 @@
 <?php
 
+namespace Rakit\Validation\Tests;
 
-class AfterTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\After;
+use PHPUnit\Framework\TestCase;
+use DateTime;
+
+class AfterTest extends TestCase
 {
 
     /**
@@ -11,7 +16,7 @@ class AfterTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->validator = new \Rakit\Validation\Rules\After();
+        $this->validator = new After();
     }
 
     /**

--- a/tests/Rules/AlphaDashTest.php
+++ b/tests/Rules/AlphaDashTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\AlphaDash;
+namespace Rakit\Validation\Tests;
 
-class AlphaDashTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\AlphaDash;
+use PHPUnit\Framework\TestCase;
+
+class AlphaDashTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/AlphaNumTest.php
+++ b/tests/Rules/AlphaNumTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\AlphaNum;
+namespace Rakit\Validation\Tests;
 
-class AlphaNumTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\AlphaNum;
+use PHPUnit\Framework\TestCase;
+
+class AlphaNumTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/AlphaTest.php
+++ b/tests/Rules/AlphaTest.php
@@ -1,8 +1,12 @@
 <?php
 
-use Rakit\Validation\Rules\Alpha;
+namespace Rakit\Validation\Tests;
 
-class AlphaTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Alpha;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class AlphaTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/BeforeTest.php
+++ b/tests/Rules/BeforeTest.php
@@ -1,7 +1,12 @@
 <?php
 
+namespace Rakit\Validation\Tests;
 
-class BeforeTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Before;
+use PHPUnit\Framework\TestCase;
+use DateTime;
+
+class BeforeTest extends TestCase
 {
 
     /**
@@ -11,7 +16,7 @@ class BeforeTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->validator = new \Rakit\Validation\Rules\Before();
+        $this->validator = new Before();
     }
 
     /**

--- a/tests/Rules/BetweenTest.php
+++ b/tests/Rules/BetweenTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Between;
+namespace Rakit\Validation\Tests;
 
-class BetweenTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Between;
+use PHPUnit\Framework\TestCase;
+
+class BetweenTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/CallbackTest.php
+++ b/tests/Rules/CallbackTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Callback;
+namespace Rakit\Validation\Tests;
 
-class CallbackTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Callback;
+use PHPUnit\Framework\TestCase;
+
+class CallbackTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/DateTest.php
+++ b/tests/Rules/DateTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Date;
+namespace Rakit\Validation\Tests;
 
-class DateTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Date;
+use PHPUnit\Framework\TestCase;
+
+class DateTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/DefaultsTest.php
+++ b/tests/Rules/DefaultsTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Defaults;
+namespace Rakit\Validation\Tests;
 
-class DefaultsTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Defaults;
+use PHPUnit\Framework\TestCase;
+
+class DefaultsTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/DigitsBetweenTest.php
+++ b/tests/Rules/DigitsBetweenTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\DigitsBetween;
+namespace Rakit\Validation\Tests;
 
-class DigitsBetweenTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\DigitsBetween;
+use PHPUnit\Framework\TestCase;
+
+class DigitsBetweenTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/DigitsTest.php
+++ b/tests/Rules/DigitsTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Digits;
+namespace Rakit\Validation\Tests;
 
-class DigitsTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Digits;
+use PHPUnit\Framework\TestCase;
+
+class DigitsTest extends TestCase
 {
 
     public function setUp()
@@ -20,8 +23,8 @@ class DigitsTest extends PHPUnit_Framework_TestCase
     public function testInvalids()
     {
         $this->assertFalse($this->rule->fillParameters([7])->check(12345678));
-        $this->assertFalse($this->rule->fillParameters([4])->check(12));      
-        $this->assertFalse($this->rule->fillParameters([3])->check('foo'));      
+        $this->assertFalse($this->rule->fillParameters([4])->check(12));
+        $this->assertFalse($this->rule->fillParameters([3])->check('foo'));
     }
 
 }

--- a/tests/Rules/EmailTest.php
+++ b/tests/Rules/EmailTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Email;
+namespace Rakit\Validation\Tests;
 
-class EmailTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Email;
+use PHPUnit\Framework\TestCase;
+
+class EmailTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/InTest.php
+++ b/tests/Rules/InTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\In;
+namespace Rakit\Validation\Tests;
 
-class InTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\In;
+use PHPUnit\Framework\TestCase;
+
+class InTest extends TestCase
 {
 
     public function setUp()
@@ -24,13 +27,13 @@ class InTest extends PHPUnit_Framework_TestCase
     public function testStricts()
     {
         // Not strict
-        $this->assertTrue($this->rule->fillParameters(['1', '2', '3'])->check(1));        
+        $this->assertTrue($this->rule->fillParameters(['1', '2', '3'])->check(1));
         $this->assertTrue($this->rule->fillParameters(['1', '2', '3'])->check(true));
 
-        // Strict        
+        // Strict
         $this->rule->strict();
-        $this->assertFalse($this->rule->fillParameters(['1', '2', '3'])->check(1));        
-        $this->assertFalse($this->rule->fillParameters(['1', '2', '3'])->check(1));        
+        $this->assertFalse($this->rule->fillParameters(['1', '2', '3'])->check(1));
+        $this->assertFalse($this->rule->fillParameters(['1', '2', '3'])->check(1));
     }
 
 }

--- a/tests/Rules/IntegerTest.php
+++ b/tests/Rules/IntegerTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Integer;
+namespace Rakit\Validation\Tests;
 
-class IntegerTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Integer;
+use PHPUnit\Framework\TestCase;
+
+class IntegerTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/IpTest.php
+++ b/tests/Rules/IpTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Ip;
+namespace Rakit\Validation\Tests;
 
-class IpTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Ip;
+use PHPUnit\Framework\TestCase;
+
+class IpTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/Ipv4Test.php
+++ b/tests/Rules/Ipv4Test.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Ipv4;
+namespace Rakit\Validation\Tests;
 
-class Ipv4Test extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Ipv4;
+use PHPUnit\Framework\TestCase;
+
+class Ipv4Test extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/Ipv6Test.php
+++ b/tests/Rules/Ipv6Test.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Ipv6;
+namespace Rakit\Validation\Tests;
 
-class Ipv6Test extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Ipv6;
+use PHPUnit\Framework\TestCase;
+
+class Ipv6Test extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/JsonTest.php
+++ b/tests/Rules/JsonTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Json;
+namespace Rakit\Validation\Tests;
 
-class JsonTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Json;
+use PHPUnit\Framework\TestCase;
+
+class JsonTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/LowercaseTest.php
+++ b/tests/Rules/LowercaseTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Lowercase;
+namespace Rakit\Validation\Tests;
 
-class LowercaseTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Lowercase;
+use PHPUnit\Framework\TestCase;
+
+class LowercaseTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/MaxTest.php
+++ b/tests/Rules/MaxTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Max;
+namespace Rakit\Validation\Tests;
 
-class MaxTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Max;
+use PHPUnit\Framework\TestCase;
+
+class MaxTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/MinTest.php
+++ b/tests/Rules/MinTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Min;
+namespace Rakit\Validation\Tests;
 
-class MinTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Min;
+use PHPUnit\Framework\TestCase;
+
+class MinTest extends TestCase
 {
 
     public function setUp()
@@ -21,12 +24,12 @@ class MinTest extends PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->rule->fillParameters([7])->check('foobar'));
         $this->assertFalse($this->rule->fillParameters([4])->check([1,2,3]));
-        $this->assertFalse($this->rule->fillParameters([200])->check(123));  
+        $this->assertFalse($this->rule->fillParameters([200])->check(123));
 
         $this->assertFalse($this->rule->fillParameters([4])->check('мин'));
         $this->assertFalse($this->rule->fillParameters([5])->check('كلمة'));
         $this->assertFalse($this->rule->fillParameters([4])->check('ワード'));
-        $this->assertFalse($this->rule->fillParameters([2])->check('字'));      
+        $this->assertFalse($this->rule->fillParameters([2])->check('字'));
     }
 
 }

--- a/tests/Rules/NotInTest.php
+++ b/tests/Rules/NotInTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\NotIn;
+namespace Rakit\Validation\Tests;
 
-class NotInTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\NotIn;
+use PHPUnit\Framework\TestCase;
+
+class NotInTest extends TestCase
 {
 
     public function setUp()
@@ -24,13 +27,13 @@ class NotInTest extends PHPUnit_Framework_TestCase
     public function testStricts()
     {
         // Not strict
-        $this->assertFalse($this->rule->fillParameters(['1', '2', '3'])->check(1));        
+        $this->assertFalse($this->rule->fillParameters(['1', '2', '3'])->check(1));
         $this->assertFalse($this->rule->fillParameters(['1', '2', '3'])->check(true));
 
-        // Strict        
+        // Strict
         $this->rule->strict();
-        $this->assertTrue($this->rule->fillParameters(['1', '2', '3'])->check(1));        
-        $this->assertTrue($this->rule->fillParameters(['1', '2', '3'])->check(1));        
+        $this->assertTrue($this->rule->fillParameters(['1', '2', '3'])->check(1));
+        $this->assertTrue($this->rule->fillParameters(['1', '2', '3'])->check(1));
     }
 
 }

--- a/tests/Rules/NumericTest.php
+++ b/tests/Rules/NumericTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Numeric;
+namespace Rakit\Validation\Tests;
 
-class NumericTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Numeric;
+use PHPUnit\Framework\TestCase;
+
+class NumericTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/RegexTest.php
+++ b/tests/Rules/RegexTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Regex;
+namespace Rakit\Validation\Tests;
 
-class RegexTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Regex;
+use PHPUnit\Framework\TestCase;
+
+class RegexTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/RequiredTest.php
+++ b/tests/Rules/RequiredTest.php
@@ -1,8 +1,12 @@
 <?php
 
-use Rakit\Validation\Rules\Required;
+namespace Rakit\Validation\Tests;
 
-class RequiredTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Required;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class RequiredTest extends TestCase
 {
 
     public function setUp()
@@ -18,7 +22,7 @@ class RequiredTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->rule->check(true));
         $this->assertTrue($this->rule->check('0'));
         $this->assertTrue($this->rule->check(0));
-        $this->assertTrue($this->rule->check(new \stdClass));
+        $this->assertTrue($this->rule->check(new stdClass));
     }
 
     public function testInvalids()

--- a/tests/Rules/TypeArrayTest.php
+++ b/tests/Rules/TypeArrayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\TypeArray;
+namespace Rakit\Validation\Tests;
 
-class TypeArrayTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\TypeArray;
+use PHPUnit\Framework\TestCase;
+
+class TypeArrayTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/UploadedFileTest.php
+++ b/tests/Rules/UploadedFileTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\UploadedFile;
+namespace Rakit\Validation\Tests;
 
-class UploadedFileTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\UploadedFile;
+use PHPUnit\Framework\TestCase;
+
+class UploadedFileTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/UppercaseTest.php
+++ b/tests/Rules/UppercaseTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Uppercase;
+namespace Rakit\Validation\Tests;
 
-class UppercaseTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Uppercase;
+use PHPUnit\Framework\TestCase;
+
+class UppercaseTest extends TestCase
 {
 
     public function setUp()

--- a/tests/Rules/UrlTest.php
+++ b/tests/Rules/UrlTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Rakit\Validation\Rules\Url;
+namespace Rakit\Validation\Tests;
 
-class UrlTest extends PHPUnit_Framework_TestCase
+use Rakit\Validation\Rules\Url;
+use PHPUnit\Framework\TestCase;
+
+class UrlTest extends TestCase
 {
 
     public function setUp()

--- a/tests/ValidatonTest.php
+++ b/tests/ValidatonTest.php
@@ -1,9 +1,13 @@
 <?php
 
+namespace Rakit\Validation\Tests;
+
 use Rakit\Validation\Validation;
 use Rakit\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
-class ValidatonTest extends PHPUnit_Framework_TestCase
+class ValidatonTest extends TestCase
 {
     /**
      * @param string $rules

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1,11 +1,12 @@
 <?php
 
+namespace Rakit\Validation\Tests;
+
 use Rakit\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+use DateTime;
 
-require_once 'Fixtures/Even.php';
-require_once 'Fixtures/Required.php';
-
-class ValidatorTest extends PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
 
     protected $validator;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
# Changed log
- Set different PHPUnit versions to support multiple PHP versions.
- Using class-based PHPUnit namespace to be compatible with latest PHPUnit version.
- Drop the `php-5.5` and `php-5.6` versions support because these PHP versions will be end of life.
- Add the namespace for the classes in `tests` folder.
- Add the `tests/bootstrap.php` file to load the all required files once before doing unit test work.