### PR TITLE
Complete type hints and annotation comments

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -5,23 +5,40 @@ namespace Rakit\Validation;
 class Attribute
 {
 
+    /** @var array */
     protected $rules = [];
 
+    /** @var mixed */
     protected $key;
 
+    /** @var mixed */
     protected $alias;
 
+    /** @var mixed */
     protected $validation;
 
+    /** @var bool */
     protected $required = false;
 
+    /** @var Attribute */
     protected $primaryAttribute = null;
 
+    /** @var array */
     protected $otherAttributes = [];
 
+    /** @var array */
     protected $keyIndexes = [];
 
-    public function __construct(Validation $validation, $key, $alias = null, array $rules = array())
+    /**
+     * Constructor
+     *
+     * @param Validation $validation
+     * @param mixed $key
+     * @param mixed $alias
+     * @param array $rules
+     * @return void
+     */
+    public function __construct(Validation $validation, $key, $alias = null, array $rules = [])
     {
         $this->validation = $validation;
         $this->alias = $alias;
@@ -31,21 +48,44 @@ class Attribute
         }
     }
 
+    /**
+     * Set the primary attribute
+     *
+     * @param Attribute $primaryAttribute
+     * @return void
+     */
     public function setPrimaryAttribute(Attribute $primaryAttribute)
     {
         $this->primaryAttribute = $primaryAttribute;
     }
 
+    /**
+     * Set key indexes
+     *
+     * @param array $keyIndexes
+     * @return void
+     */
     public function setKeyIndexes(array $keyIndexes)
     {
         $this->keyIndexes = $keyIndexes;
     }
 
+    /**
+     * Get primary attributes
+     *
+     * @return mixed
+     */
     public function getPrimaryAttribute()
     {
         return $this->primaryAttribute;
     }
 
+    /**
+     * Set other attributes
+     *
+     * @param array $otherAttributes
+     * @return void
+     */
     public function setOtherAttributes(array $otherAttributes)
     {
         $this->otherAttributes = [];
@@ -54,16 +94,33 @@ class Attribute
         }
     }
 
+    /**
+     * Add other attributes
+     *
+     * @param Attribute $otherAttribute
+     * @return void
+     */
     public function addOtherAttribute(Attribute $otherAttribute)
     {
         $this->otherAttributes[] = $otherAttribute;
     }
 
-    public function getOtherAttributes()
+    /**
+     * Get other attributes
+     *
+     * @return array
+     */
+    public function getOtherAttributes(): array
     {
         return $this->otherAttributes;
     }
 
+    /**
+     * Add rule
+     *
+     * @param Rule $rule
+     * @return void
+     */
     public function addRule(Rule $rule)
     {
         $rule->setAttribute($this);
@@ -71,41 +128,85 @@ class Attribute
         $this->rules[$rule->getKey()] = $rule;
     }
 
+    /**
+     * Get rule
+     *
+     * @param mixed $ruleKey
+     * @return void
+     */
     public function getRule($ruleKey)
     {
         return $this->hasRule($ruleKey)? $this->rules[$ruleKey] : null;
     }
 
-    public function getRules()
+    /**
+     * Get rules
+     *
+     * @return array
+     */
+    public function getRules(): array
     {
         return $this->rules;
     }
 
-    public function hasRule($ruleKey)
+    /**
+     * Check the $ruleKey has in the rule
+     *
+     * @param mixed $ruleKey
+     * @return bool
+     */
+    public function hasRule($ruleKey): bool
     {
         return isset($this->rules[$ruleKey]);
     }
 
+    /**
+     * Set required
+     *
+     * @param mixed $required
+     * @return void
+     */
     public function setRequired($required)
     {
         $this->required = $required;
     }
 
-    public function isRequired()
+    /**
+     * Set rule is required
+     *
+     * @return boolean
+     */
+    public function isRequired(): bool
     {
         return $this->required === true;
     }
 
-    public function getKey()
+    /**
+     * Get key
+     *
+     * @return string
+     */
+    public function getKey(): string
     {
         return $this->key;
     }
 
-    public function getKeyIndexes()
+    /**
+     * Get key indexes
+     *
+     * @return array
+     */
+    public function getKeyIndexes(): array
     {
         return $this->keyIndexes;
     }
 
+    /**
+     * Get value
+     *
+     * @param mixed $key
+     * @return void
+     */
     public function getValue($key = null)
     {
         if ($key && $this->isArrayAttribute()) {
@@ -119,16 +220,32 @@ class Attribute
         return $this->validation->getValue($key);
     }
 
+    /**
+     * Get that is array attribute
+     *
+     * @return boolean
+     */
     public function isArrayAttribute()
     {
         return count($this->getKeyIndexes()) > 0;
     }
 
+    /**
+     * Check that is using dot notation
+     *
+     * @return boolean
+     */
     public function isUsingDotNotation()
     {
         return strpos($this->getKey(), '.') !== false;
     }
 
+    /**
+     * Resolve sibling key
+     *
+     * @param mixed $key
+     * @return mixed
+     */
     public function resolveSiblingKey($key)
     {
         $indexes = $this->getKeyIndexes();
@@ -141,6 +258,11 @@ class Attribute
         return call_user_func_array('sprintf', $args);
     }
 
+    /**
+     * Get humanize key
+     *
+     * @return string
+     */
     public function getHumanizedKey()
     {
         $primaryAttribute = $this->getPrimaryAttribute();
@@ -160,11 +282,22 @@ class Attribute
         return ucfirst($key);
     }
 
+    /**
+     * Set alias
+     *
+     * @param mixed $alias
+     * @return void
+     */
     public function setAlias($alias)
     {
         $this->alias = $alias;
     }
 
+    /**
+     * Get alias
+     *
+     * @return mixed
+     */
     public function getAlias()
     {
         return $this->alias;

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -182,7 +182,7 @@ class Attribute
      */
     public function isRequired(): bool
     {
-        return $this->required === true;
+        return $this->required;
     }
 
     /**

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -8,19 +8,19 @@ class Attribute
     /** @var array */
     protected $rules = [];
 
-    /** @var mixed */
+    /** @var string */
     protected $key;
 
-    /** @var mixed */
+    /** @var string|null */
     protected $alias;
 
-    /** @var mixed */
+    /** @var Rakit\Validation\Validation */
     protected $validation;
 
     /** @var bool */
     protected $required = false;
 
-    /** @var Attribute */
+    /** @var Rakit\Validation\Validation|null */
     protected $primaryAttribute = null;
 
     /** @var array */
@@ -32,14 +32,18 @@ class Attribute
     /**
      * Constructor
      *
-     * @param Validation $validation
-     * @param mixed $key
-     * @param mixed $alias
-     * @param array $rules
+     * @param Rakit\Validation\Validation  $validation
+     * @param string      $key
+     * @param string|null $alias
+     * @param array       $rules
      * @return void
      */
-    public function __construct(Validation $validation, $key, $alias = null, array $rules = [])
-    {
+    public function __construct(
+        Validation $validation,
+        string $key,
+        $alias = null,
+        array $rules = []
+    ) {
         $this->validation = $validation;
         $this->alias = $alias;
         $this->key = $key;
@@ -51,7 +55,7 @@ class Attribute
     /**
      * Set the primary attribute
      *
-     * @param Attribute $primaryAttribute
+     * @param Rakit\Validation\Attribute $primaryAttribute
      * @return void
      */
     public function setPrimaryAttribute(Attribute $primaryAttribute)
@@ -73,7 +77,7 @@ class Attribute
     /**
      * Get primary attributes
      *
-     * @return mixed
+     * @return Rakit\Validation\Attribute|null
      */
     public function getPrimaryAttribute()
     {
@@ -97,7 +101,7 @@ class Attribute
     /**
      * Add other attributes
      *
-     * @param Attribute $otherAttribute
+     * @param Rakit\Validation\Attribute $otherAttribute
      * @return void
      */
     public function addOtherAttribute(Attribute $otherAttribute)
@@ -118,7 +122,7 @@ class Attribute
     /**
      * Add rule
      *
-     * @param Rule $rule
+     * @param Rakit\Validation\Rule $rule
      * @return void
      */
     public function addRule(Rule $rule)
@@ -131,10 +135,10 @@ class Attribute
     /**
      * Get rule
      *
-     * @param mixed $ruleKey
+     * @param string $ruleKey
      * @return void
      */
-    public function getRule($ruleKey)
+    public function getRule(string $ruleKey)
     {
         return $this->hasRule($ruleKey)? $this->rules[$ruleKey] : null;
     }
@@ -152,10 +156,10 @@ class Attribute
     /**
      * Check the $ruleKey has in the rule
      *
-     * @param mixed $ruleKey
+     * @param string $ruleKey
      * @return bool
      */
-    public function hasRule($ruleKey): bool
+    public function hasRule(string $ruleKey): bool
     {
         return isset($this->rules[$ruleKey]);
     }
@@ -163,10 +167,10 @@ class Attribute
     /**
      * Set required
      *
-     * @param mixed $required
+     * @param boolean $required
      * @return void
      */
-    public function setRequired($required)
+    public function setRequired(bool $required)
     {
         $this->required = $required;
     }
@@ -204,10 +208,10 @@ class Attribute
     /**
      * Get value
      *
-     * @param mixed $key
+     * @param string|null $key
      * @return void
      */
-    public function getValue($key = null)
+    public function getValue(string $key = null)
     {
         if ($key && $this->isArrayAttribute()) {
             $key = $this->resolveSiblingKey($key);
@@ -225,17 +229,17 @@ class Attribute
      *
      * @return boolean
      */
-    public function isArrayAttribute()
+    public function isArrayAttribute(): bool
     {
         return count($this->getKeyIndexes()) > 0;
     }
 
     /**
-     * Check that is using dot notation
+     * Check this attribute is using dot notation
      *
      * @return boolean
      */
-    public function isUsingDotNotation()
+    public function isUsingDotNotation(): bool
     {
         return strpos($this->getKey(), '.') !== false;
     }
@@ -243,10 +247,10 @@ class Attribute
     /**
      * Resolve sibling key
      *
-     * @param mixed $key
-     * @return mixed
+     * @param string $key
+     * @return string
      */
-    public function resolveSiblingKey($key)
+    public function resolveSiblingKey(string $key): string
     {
         $indexes = $this->getKeyIndexes();
         $keys = explode("*", $key);
@@ -285,10 +289,10 @@ class Attribute
     /**
      * Set alias
      *
-     * @param mixed $alias
+     * @param string $alias
      * @return void
      */
-    public function setAlias($alias)
+    public function setAlias(string $alias)
     {
         $this->alias = $alias;
     }
@@ -296,7 +300,7 @@ class Attribute
     /**
      * Get alias
      *
-     * @return mixed
+     * @return string|null
      */
     public function getAlias()
     {

--- a/src/ErrorBag.php
+++ b/src/ErrorBag.php
@@ -5,13 +5,28 @@ namespace Rakit\Validation;
 class ErrorBag
 {
 
+    /** @var array */
     protected $messages = [];
 
+    /**
+     * Constructor
+     *
+     * @param array $messages
+     * @return void
+     */
     public function __construct(array $messages = [])
     {
         $this->messages = $messages;
     }
 
+    /**
+     * Add key,rule and message
+     *
+     * @param mixed $key
+     * @param mixed $rule
+     * @param mixed $message
+     * @return void
+     */
     public function add($key, $rule, $message)
     {
         if (!isset($this->messages[$key])) {
@@ -21,12 +36,23 @@ class ErrorBag
         $this->messages[$key][$rule] = $message;
     }
 
-    public function count()
+    /**
+     * Get results count
+     *
+     * @return int
+     */
+    public function count(): int
     {
         return count($this->all());
     }
 
-    public function has($key)
+    /**
+     * Check given key is existed
+     *
+     * @param mixed $key
+     * @return bool
+     */
+    public function has($key): bool
     {
         list($key, $ruleName) = $this->parsekey($key);
         if ($this->isWildcardKey($key)) {
@@ -43,6 +69,12 @@ class ErrorBag
         }
     }
 
+    /**
+     * Get the first value of array
+     *
+     * @param mixed $key
+     * @return mixed
+     */
     public function first($key)
     {
         list($key, $ruleName) = $this->parsekey($key);
@@ -65,7 +97,14 @@ class ErrorBag
         }
     }
 
-    public function get($key, $format = ':message')
+    /**
+     * Given $key and $format then get the results
+     *
+     * @param mixed $key
+     * @param string $format
+     * @return array
+     */
+    public function get($key, string $format = ':message'): array
     {
         list($key, $ruleName) = $this->parsekey($key);
         $results = [];
@@ -89,7 +128,13 @@ class ErrorBag
         return $results;
     }
 
-    public function all($format = ':message')
+    /**
+     * Get all results
+     *
+     * @param string $format
+     * @return array
+     */
+    public function all(string $format = ':message'): array
     {
         $messages = $this->messages;
         $results = [];
@@ -101,7 +146,14 @@ class ErrorBag
         return $results;
     }
 
-    public function firstOfAll($format = ':message', $dotNotation = false)
+    /**
+     * Get the first result of results
+     *
+     * @param string $format
+     * @param boolean $dotNotation
+     * @return array
+     */
+    public function firstOfAll(string $format = ':message', bool $dotNotation = false): array
     {
         $messages = $this->messages;
         $results = [];
@@ -115,12 +167,23 @@ class ErrorBag
         return $results;
     }
 
-    public function toArray()
+    /**
+     * Get messagees
+     *
+     * @return array
+     */
+    public function toArray(): array
     {
         return $this->messages;
     }
 
-    protected function parseKey($key)
+    /**
+     * Parse $key to get the array of $key and $ruleName
+     *
+     * @param mixed $key
+     * @return array
+     */
+    protected function parseKey($key): array
     {
         $expl = explode(':', $key, 2);
         $key = $expl[0];
@@ -128,12 +191,25 @@ class ErrorBag
         return [$key, $ruleName];
     }
 
-    protected function isWildcardKey($key)
+    /**
+     * Check the $key is wildcard
+     *
+     * @param mixed $key
+     * @return bool
+     */
+    protected function isWildcardKey($key): bool
     {
         return false !== strpos($key, '*');
     }
 
-    protected function filterMessagesForWildcardKey($key, $ruleName = null)
+    /**
+     * Filter messages with wildcard key
+     *
+     * @param mixed $key
+     * @param mixed $ruleName
+     * @return array
+     */
+    protected function filterMessagesForWildcardKey($key, $ruleName = null): array
     {
         $messages = $this->messages;
         $pattern = preg_quote($key, '#');
@@ -157,7 +233,14 @@ class ErrorBag
         return $filteredMessages;
     }
 
-    protected function formatMessage($message, $format)
+    /**
+     * Get formatted message
+     *
+     * @param mixed $message
+     * @param mixed $format
+     * @return string
+     */
+    protected function formatMessage($message, $format): string
     {
         return str_replace(':message', $message, $format);
     }

--- a/src/ErrorBag.php
+++ b/src/ErrorBag.php
@@ -20,14 +20,14 @@ class ErrorBag
     }
 
     /**
-     * Add key,rule and message
+     * Add message for given key and rule
      *
-     * @param mixed $key
-     * @param mixed $rule
-     * @param mixed $message
+     * @param string $key
+     * @param string $rule
+     * @param string $message
      * @return void
      */
-    public function add($key, $rule, $message)
+    public function add(string $key, string $rule, string $message)
     {
         if (!isset($this->messages[$key])) {
             $this->messages[$key] = [];
@@ -37,7 +37,7 @@ class ErrorBag
     }
 
     /**
-     * Get results count
+     * Get messages count
      *
      * @return int
      */
@@ -49,10 +49,10 @@ class ErrorBag
     /**
      * Check given key is existed
      *
-     * @param mixed $key
+     * @param string $key
      * @return bool
      */
-    public function has($key): bool
+    public function has(string $key): bool
     {
         list($key, $ruleName) = $this->parsekey($key);
         if ($this->isWildcardKey($key)) {
@@ -72,10 +72,10 @@ class ErrorBag
     /**
      * Get the first value of array
      *
-     * @param mixed $key
+     * @param string $key
      * @return mixed
      */
-    public function first($key)
+    public function first(string $key)
     {
         list($key, $ruleName) = $this->parsekey($key);
         if ($this->isWildcardKey($key)) {
@@ -98,13 +98,13 @@ class ErrorBag
     }
 
     /**
-     * Given $key and $format then get the results
+     * Get messages from given key, can be use custom format
      *
-     * @param mixed $key
+     * @param string $key
      * @param string $format
      * @return array
      */
-    public function get($key, string $format = ':message'): array
+    public function get(string $key, string $format = ':message'): array
     {
         list($key, $ruleName) = $this->parsekey($key);
         $results = [];
@@ -129,7 +129,7 @@ class ErrorBag
     }
 
     /**
-     * Get all results
+     * Get all messages
      *
      * @param string $format
      * @return array
@@ -147,7 +147,7 @@ class ErrorBag
     }
 
     /**
-     * Get the first result of results
+     * Get the first message from existing keys
      *
      * @param string $format
      * @param boolean $dotNotation
@@ -168,7 +168,7 @@ class ErrorBag
     }
 
     /**
-     * Get messagees
+     * Get plain array messages
      *
      * @return array
      */
@@ -180,10 +180,10 @@ class ErrorBag
     /**
      * Parse $key to get the array of $key and $ruleName
      *
-     * @param mixed $key
+     * @param string $key
      * @return array
      */
-    protected function parseKey($key): array
+    protected function parseKey(string $key): array
     {
         $expl = explode(':', $key, 2);
         $key = $expl[0];
@@ -197,7 +197,7 @@ class ErrorBag
      * @param mixed $key
      * @return bool
      */
-    protected function isWildcardKey($key): bool
+    protected function isWildcardKey(string $key): bool
     {
         return false !== strpos($key, '*');
     }
@@ -205,11 +205,11 @@ class ErrorBag
     /**
      * Filter messages with wildcard key
      *
-     * @param mixed $key
-     * @param mixed $ruleName
+     * @param string $key
+     * @param mixed  $ruleName
      * @return array
      */
-    protected function filterMessagesForWildcardKey($key, $ruleName = null): array
+    protected function filterMessagesForWildcardKey(string $key, $ruleName = null): array
     {
         $messages = $this->messages;
         $pattern = preg_quote($key, '#');
@@ -236,11 +236,11 @@ class ErrorBag
     /**
      * Get formatted message
      *
-     * @param mixed $message
-     * @param mixed $format
+     * @param string $message
+     * @param string $format
      * @return string
      */
-    protected function formatMessage($message, $format): string
+    protected function formatMessage(string $message, string $format): string
     {
         return str_replace(':message', $message, $format);
     }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -9,8 +9,8 @@ class Helper
      * Determine if a given string matches a given pattern.
      * Adapted from: https://github.com/illuminate/support/blob/v5.3.23/Str.php#L119
      *
-     * @param  string  $pattern
-     * @param  string  $value
+     * @param  string $pattern
+     * @param  string $value
      * @return bool
      */
     public static function strIs(string $pattern, string $value): bool
@@ -33,11 +33,11 @@ class Helper
      * Check if an item or items exist in an array using "dot" notation.
      * Adapted from: https://github.com/illuminate/support/blob/v5.3.23/Arr.php#L81
      *
-     * @param  array  $array
-     * @param  string|array  $keys
+     * @param  array $array
+     * @param  string $key
      * @return bool
      */
-    public static function arrayHas(array $array, $key): bool
+    public static function arrayHas(array $array, string $key): bool
     {
         if (array_key_exists($key, $array)) {
             return true;
@@ -59,11 +59,11 @@ class Helper
      * Adapted from: https://github.com/illuminate/support/blob/v5.3.23/Arr.php#L246
      *
      * @param  array  $array
-     * @param  string  $key
-     * @param  mixed   $default
+     * @param  string $key
+     * @param  mixed  $default
      * @return mixed
      */
-    public static function arrayGet(array $array, $key, $default = null)
+    public static function arrayGet(array $array, string $key, $default = null)
     {
         if (is_null($key)) {
             return $array;
@@ -88,8 +88,8 @@ class Helper
      * Flatten a multi-dimensional associative array with dots.
      * Adapted from: https://github.com/illuminate/support/blob/v5.3.23/Arr.php#L81
      *
-     * @param  array   $array
-     * @param  string  $prepend
+     * @param  array  $array
+     * @param  string $prepend
      * @return array
      */
     public static function arrayDot(array $array, string $prepend = ''): array
@@ -111,10 +111,10 @@ class Helper
      * Set an item on an array or object using dot notation.
      * Adapted from: https://github.com/illuminate/support/blob/v5.3.23/helpers.php#L437
      *
-     * @param  mixed  $target
-     * @param  string|array  $key
-     * @param  mixed  $value
-     * @param  bool  $overwrite
+     * @param  mixed        $target
+     * @param  string|array $key
+     * @param  mixed        $value
+     * @param  bool         $overwrite
      * @return mixed
      */
     public static function arraySet(&$target, $key, $value, $overwrite = true): array
@@ -158,12 +158,11 @@ class Helper
         return $target;
     }
 
-
     /**
      * Unset an item on an array or object using dot notation.
      *
-     * @param  mixed  $target
-     * @param  string|array  $key
+     * @param  mixed        $target
+     * @param  string|array $key
      * @return mixed
      */
     public static function arrayUnset(&$target, $key): array

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -13,7 +13,7 @@ class Helper
      * @param  string  $value
      * @return bool
      */
-    public static function strIs($pattern, $value)
+    public static function strIs(string $pattern, string $value): bool
     {
         if ($pattern == $value) {
             return true;
@@ -37,7 +37,7 @@ class Helper
      * @param  string|array  $keys
      * @return bool
      */
-    public static function arrayHas(array $array, $key)
+    public static function arrayHas(array $array, $key): bool
     {
         if (array_key_exists($key, $array)) {
             return true;
@@ -92,7 +92,7 @@ class Helper
      * @param  string  $prepend
      * @return array
      */
-    public static function arrayDot(array $array, $prepend = '')
+    public static function arrayDot(array $array, string $prepend = ''): array
     {
         $results = [];
 
@@ -117,7 +117,7 @@ class Helper
      * @param  bool  $overwrite
      * @return mixed
      */
-    public static function arraySet(&$target, $key, $value, $overwrite = true)
+    public static function arraySet(&$target, $key, $value, $overwrite = true): array
     {
         $segments = is_array($key) ? $key : explode('.', $key);
 
@@ -166,7 +166,7 @@ class Helper
      * @param  string|array  $key
      * @return mixed
      */
-    public static function arrayUnset(&$target, $key)
+    public static function arrayUnset(&$target, $key): array
     {
         if (!is_array($target)) {
             return $target;
@@ -195,7 +195,7 @@ class Helper
      * @param  string $delimiter
      * @return string
      */
-    public static function snakeCase($value, $delimiter = '_')
+    public static function snakeCase(string $value, string $delimiter = '_'): string
     {
         if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/u', '', ucwords($value));

--- a/src/MimeTypeGuesser.php
+++ b/src/MimeTypeGuesser.php
@@ -5,6 +5,7 @@ namespace Rakit\Validation;
 class MimeTypeGuesser
 {
 
+    /** @var array */
     protected $mimeTypes = [
         'application/andrew-inset' => 'ez',
         'application/applixware' => 'aw',
@@ -778,11 +779,23 @@ class MimeTypeGuesser
         'x-conference/x-cooltalk' => 'ice'
     ];
 
+    /**
+     * Get extension name
+     *
+     * @param mixed $mimeType
+     * @return mixed
+     */
     public function getExtension($mimeType)
     {
         return isset($this->mimeTypes[$mimeType])? $this->mimeTypes[$mimeType] : null;
     }
 
+    /**
+     * Get mime type
+     *
+     * @param mixed $extension
+     * @return mixed
+     */
     public function getMimeType($extension)
     {
         $key = array_search($extension, $this->mimeTypes);

--- a/src/MimeTypeGuesser.php
+++ b/src/MimeTypeGuesser.php
@@ -780,23 +780,23 @@ class MimeTypeGuesser
     ];
 
     /**
-     * Get extension name
+     * Get extension by mime type
      *
-     * @param mixed $mimeType
-     * @return mixed
+     * @param string $mimeType
+     * @return string|null
      */
-    public function getExtension($mimeType)
+    public function getExtension(string $mimeType)
     {
         return isset($this->mimeTypes[$mimeType])? $this->mimeTypes[$mimeType] : null;
     }
 
     /**
-     * Get mime type
+     * Get mime type by extension
      *
-     * @param mixed $extension
-     * @return mixed
+     * @param string $extension
+     * @return string|null
      */
-    public function getMimeType($extension)
+    public function getMimeType(string $extension)
     {
         $key = array_search($extension, $this->mimeTypes);
         return $key ?: null;

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -6,13 +6,13 @@ use Rakit\Validation\MissingRequiredParameterException;
 
 abstract class Rule
 {
-    /** @var mixed */
+    /** @var string */
     protected $key;
 
-    /** @var mixed */
+    /** @var Rakit\Validation\Attribute|null */
     protected $attribute;
 
-    /** @var mixed */
+    /** @var Rakit\Validation\Validation|null */
     protected $validation;
 
     /** @var bool */
@@ -32,10 +32,10 @@ abstract class Rule
     /**
      * Set Validation class instance
      *
-     * @param Validation $validation
+     * @param Rakit\Validation\Validation $validation
      * @return void
      */
-    public function setValidation(Validation $validation)
+    public function setValidation(Validation $validation): void
     {
         $this->validation = $validation;
     }
@@ -43,10 +43,10 @@ abstract class Rule
     /**
      * Set key
      *
-     * @param mixed $key
+     * @param string $key
      * @return void
      */
-    public function setKey($key)
+    public function setKey(string $key): void
     {
         $this->key = $key;
     }
@@ -54,7 +54,7 @@ abstract class Rule
     /**
      * Get key
      *
-     * @return mixed
+     * @return string
      */
     public function getKey()
     {
@@ -64,10 +64,10 @@ abstract class Rule
     /**
      * Set attribute
      *
-     * @param mixed $attribute
+     * @param Rakit\Validation\Attribute $attribute
      * @return void
      */
-    public function setAttribute($attribute)
+    public function setAttribute(Attribute $attribute): void
     {
         $this->attribute = $attribute;
     }
@@ -75,11 +75,11 @@ abstract class Rule
     /**
      * Get attribute
      *
-     * @return mixed
+     * @return Rakit\Validation\Attribute|null
      */
     public function getAttribute()
     {
-        return $this->attribute ?: get_class($this);
+        return $this->attribute;
     }
 
     /**
@@ -96,7 +96,7 @@ abstract class Rule
      * Set params
      *
      * @param array $params
-     * @return Rule
+     * @return Rakit\Validation\Rule
      */
     public function setParameters(array $params): Rule
     {
@@ -107,11 +107,11 @@ abstract class Rule
     /**
      * Set parameters
      *
-     * @param mixed $key
+     * @param string $key
      * @param mixed $value
-     * @return Rule
+     * @return Rakit\Validation\Rule
      */
-    public function setParameter($key, $value): Rule
+    public function setParameter(string $key, $value): Rule
     {
         $this->params[$key] = $value;
         return $this;
@@ -121,7 +121,7 @@ abstract class Rule
      * Fill $params to $this->params
      *
      * @param array $params
-     * @return Rule
+     * @return Rakit\Validation\Rule
      */
     public function fillParameters(array $params): Rule
     {
@@ -135,18 +135,18 @@ abstract class Rule
     }
 
     /**
-     * Given $key and check is existed in $this->params
+     * Get parameter from given $key, return null if it not exists
      *
-     * @param mixed $key
-     * @return void
+     * @param string $key
+     * @return mixed
      */
-    public function parameter($key)
+    public function parameter(string $key)
     {
         return isset($this->params[$key])? $this->params[$key] : null;
     }
 
     /**
-     * Check $this->isImplicit is true
+     * Check whether this rule is implicit
      *
      * @return boolean
      */
@@ -156,12 +156,12 @@ abstract class Rule
     }
 
     /**
-     * Set message
+     * Just alias of setMessage
      *
-     * @param mixed $message
-     * @return Rule
+     * @param string $message
+     * @return Rakit\Validation\Rule
      */
-    public function message($message): Rule
+    public function message(string $message): Rule
     {
         return $this->setMessage($message);
     }
@@ -169,10 +169,10 @@ abstract class Rule
     /**
      * Set message
      *
-     * @param mixed $message
-     * @return Rule
+     * @param string $message
+     * @return Rakit\Validation\Rule
      */
-    public function setMessage($message): Rule
+    public function setMessage(string $message): Rule
     {
         $this->message = $message;
         return $this;
@@ -181,20 +181,21 @@ abstract class Rule
     /**
      * Get message
      *
-     * @return void
+     * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
 
     /**
-     * Check $params are existed in $this->params
+     * Check given $params must be exists
      *
      * @param array $params
      * @return void
+     * @throws Rakit\Validation\MissingRequiredParameterException
      */
-    protected function requireParameters(array $params)
+    protected function requireParameters(array $params): void
     {
         foreach ($params as $param) {
             if (!isset($this->params[$param])) {

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -35,7 +35,7 @@ abstract class Rule
      * @param Rakit\Validation\Validation $validation
      * @return void
      */
-    public function setValidation(Validation $validation): void
+    public function setValidation(Validation $validation)
     {
         $this->validation = $validation;
     }
@@ -46,7 +46,7 @@ abstract class Rule
      * @param string $key
      * @return void
      */
-    public function setKey(string $key): void
+    public function setKey(string $key)
     {
         $this->key = $key;
     }
@@ -67,7 +67,7 @@ abstract class Rule
      * @param Rakit\Validation\Attribute $attribute
      * @return void
      */
-    public function setAttribute(Attribute $attribute): void
+    public function setAttribute(Attribute $attribute)
     {
         $this->attribute = $attribute;
     }
@@ -195,7 +195,7 @@ abstract class Rule
      * @return void
      * @throws Rakit\Validation\MissingRequiredParameterException
      */
-    protected function requireParameters(array $params): void
+    protected function requireParameters(array $params)
     {
         foreach ($params as $param) {
             if (!isset($this->params[$param])) {

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -6,65 +6,124 @@ use Rakit\Validation\MissingRequiredParameterException;
 
 abstract class Rule
 {
+    /** @var mixed */
     protected $key;
 
+    /** @var mixed */
     protected $attribute;
 
+    /** @var mixed */
     protected $validation;
 
+    /** @var bool */
     protected $implicit = false;
 
+    /** @var array */
     protected $params = [];
 
+    /** @var array */
     protected $fillableParams = [];
 
+    /** @var string */
     protected $message = "The :attribute is invalid";
 
     abstract public function check($value);
 
+    /**
+     * Set Validation class instance
+     *
+     * @param Validation $validation
+     * @return void
+     */
     public function setValidation(Validation $validation)
     {
         $this->validation = $validation;
     }
 
+    /**
+     * Set key
+     *
+     * @param mixed $key
+     * @return void
+     */
     public function setKey($key)
     {
         $this->key = $key;
     }
 
+    /**
+     * Get key
+     *
+     * @return mixed
+     */
     public function getKey()
     {
         return $this->key ?: get_class($this);
     }
 
+    /**
+     * Set attribute
+     *
+     * @param mixed $attribute
+     * @return void
+     */
     public function setAttribute($attribute)
     {
         $this->attribute = $attribute;
     }
 
+    /**
+     * Get attribute
+     *
+     * @return mixed
+     */
     public function getAttribute()
     {
         return $this->attribute ?: get_class($this);
     }
 
-    public function getParameters()
+    /**
+     * Get parameters
+     *
+     * @return array
+     */
+    public function getParameters(): array
     {
         return $this->params;
     }
 
-    public function setParameters(array $params)
+    /**
+     * Set params
+     *
+     * @param array $params
+     * @return Rule
+     */
+    public function setParameters(array $params): Rule
     {
         $this->params = array_merge($this->params, $params);
         return $this;
     }
 
-    public function setParameter($key, $value)
+    /**
+     * Set parameters
+     *
+     * @param mixed $key
+     * @param mixed $value
+     * @return Rule
+     */
+    public function setParameter($key, $value): Rule
     {
         $this->params[$key] = $value;
         return $this;
     }
 
-    public function fillParameters(array $params)
+    /**
+     * Fill $params to $this->params
+     *
+     * @param array $params
+     * @return Rule
+     */
+    public function fillParameters(array $params): Rule
     {
         foreach ($this->fillableParams as $key) {
             if (empty($params)) {
@@ -75,32 +134,66 @@ abstract class Rule
         return $this;
     }
 
+    /**
+     * Given $key and check is existed in $this->params
+     *
+     * @param mixed $key
+     * @return void
+     */
     public function parameter($key)
     {
         return isset($this->params[$key])? $this->params[$key] : null;
     }
 
-    public function isImplicit()
+    /**
+     * Check $this->isImplicit is true
+     *
+     * @return boolean
+     */
+    public function isImplicit(): bool
     {
         return $this->implicit === true;
     }
 
-    public function message($message)
+    /**
+     * Set message
+     *
+     * @param mixed $message
+     * @return Rule
+     */
+    public function message($message): Rule
     {
         return $this->setMessage($message);
     }
 
-    public function setMessage($message)
+    /**
+     * Set message
+     *
+     * @param mixed $message
+     * @return Rule
+     */
+    public function setMessage($message): Rule
     {
         $this->message = $message;
         return $this;
     }
 
+    /**
+     * Get message
+     *
+     * @return void
+     */
     public function getMessage()
     {
         return $this->message;
     }
 
+    /**
+     * Check $params are existed in $this->params
+     *
+     * @param array $params
+     * @return void
+     */
     protected function requireParameters(array $params)
     {
         foreach ($params as $param) {

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -152,7 +152,7 @@ abstract class Rule
      */
     public function isImplicit(): bool
     {
-        return $this->implicit === true;
+        return $this->implicit;
     }
 
     /**

--- a/src/Rules/Accepted.php
+++ b/src/Rules/Accepted.php
@@ -6,11 +6,19 @@ use Rakit\Validation\Rule;
 
 class Accepted extends Rule
 {
+    /** @var bool */
     protected $implicit = true;
 
+    /** @var string */
     protected $message = "The :attribute must be accepted";
 
-    public function check($value)
+    /**
+     * Check the $value is accepted
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $acceptables = ['yes', 'on', '1', 1, true, 'true'];
         return in_array($value, $acceptables, true);

--- a/src/Rules/After.php
+++ b/src/Rules/After.php
@@ -19,10 +19,10 @@ class After extends Rule
      * Check the value is valid
      *
      * @param mixed $value
-     * @return mixed
+     * @return bool
      * @throws Exception
      */
-    public function check($value)
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
         $time = $this->parameter('time');

--- a/src/Rules/After.php
+++ b/src/Rules/After.php
@@ -9,10 +9,19 @@ class After extends Rule
 
     use DateUtils;
 
+    /** @var string */
     protected $message = "The :attribute must be a date after :time.";
 
+    /** @var array */
     protected $fillableParams = ['time'];
 
+    /**
+     * Check the value is valid
+     *
+     * @param mixed $value
+     * @return mixed
+     * @throws Exception
+     */
     public function check($value)
     {
         $this->requireParameters($this->fillableParams);

--- a/src/Rules/Alpha.php
+++ b/src/Rules/Alpha.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class Alpha extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute only allows alphabet characters";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
     }

--- a/src/Rules/AlphaDash.php
+++ b/src/Rules/AlphaDash.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class AlphaDash extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute only allows a-z, 0-9, _ and -";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         if (! is_string($value) && ! is_numeric($value)) {
             return false;

--- a/src/Rules/AlphaNum.php
+++ b/src/Rules/AlphaNum.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class AlphaNum extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute only allows alphabet and numeric";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         if (! is_string($value) && ! is_numeric($value)) {
             return false;

--- a/src/Rules/Before.php
+++ b/src/Rules/Before.php
@@ -8,11 +8,20 @@ class Before extends Rule
 {
     use DateUtils;
 
+    /** @var string */
     protected $message = "The :attribute must be a date before :time.";
 
+    /** @var array */
     protected $fillableParams = ['time'];
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     * @throws Exception
+     */
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
         $time = $this->parameter('time');

--- a/src/Rules/Between.php
+++ b/src/Rules/Between.php
@@ -7,11 +7,19 @@ use Rakit\Validation\Rule;
 class Between extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute must be between :min and :max";
 
+    /** @var array */
     protected $fillableParams = ['min', 'max'];
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
 

--- a/src/Rules/Callback.php
+++ b/src/Rules/Callback.php
@@ -21,7 +21,7 @@ class Callback extends Rule
      * @param Closure $callback
      * @return self
      */
-    public function setCallback(Closure $callback): self
+    public function setCallback(Closure $callback): Rule
     {
         return $this->setParameter('callback', $callback);
     }
@@ -30,10 +30,10 @@ class Callback extends Rule
      * Check the $value is valid
      *
      * @param mixed $value
-     * @return mixed
+     * @return bool
      * @throws Exception
      */
-    public function check($value)
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
 

--- a/src/Rules/Callback.php
+++ b/src/Rules/Callback.php
@@ -9,15 +9,30 @@ use Closure;
 class Callback extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute is not valid";
 
+    /** @var array */
     protected $fillableParams = ['callback'];
 
-    public function setCallback(Closure $callback)
+    /**
+     * Set the Callback closure
+     *
+     * @param Closure $callback
+     * @return self
+     */
+    public function setCallback(Closure $callback): self
     {
         return $this->setParameter('callback', $callback);
     }
 
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return mixed
+     * @throws Exception
+     */
     public function check($value)
     {
         $this->requireParameters($this->fillableParams);

--- a/src/Rules/Date.php
+++ b/src/Rules/Date.php
@@ -7,15 +7,24 @@ use Rakit\Validation\Rule;
 class Date extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute is not valid date format";
 
+    /** @var array */
     protected $fillableParams = ['format'];
 
+    /** @var array */
     protected $params = [
         'format' => 'Y-m-d'
     ];
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
 

--- a/src/Rules/DateUtils.php
+++ b/src/Rules/DateUtils.php
@@ -7,19 +7,37 @@ use Exception;
 trait DateUtils
 {
 
-    protected function isValidDate($date)
+    /**
+     * Check the $date is valid
+     *
+     * @param string $date
+     * @return bool
+     */
+    protected function isValidDate(string $date): bool
     {
         return (strtotime($date) !== false);
     }
 
-    protected function throwException($value)
+    /**
+     * Throw exception
+     *
+     * @param string $value
+     * @return Exception
+     */
+    protected function throwException(string $value)
     {
         return new Exception(
             "Expected a valid date, got '{$value}' instead. 2016-12-08, 2016-12-02 14:58, tomorrow are considered valid dates"
         );
     }
 
-    protected function getTimeStamp($date)
+    /**
+     * Given $date and get the time stamp
+     *
+     * @param mixed $date
+     * @return int
+     */
+    protected function getTimeStamp($date): int
     {
         return strtotime($date);
     }

--- a/src/Rules/Defaults.php
+++ b/src/Rules/Defaults.php
@@ -7,10 +7,18 @@ use Rakit\Validation\Rule;
 class Defaults extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute default is :default";
 
+    /** @var array */
     protected $fillableParams = ['default'];
 
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     public function check($value)
     {
         $this->requireParameters($this->fillableParams);

--- a/src/Rules/Different.php
+++ b/src/Rules/Different.php
@@ -7,11 +7,19 @@ use Rakit\Validation\Rule;
 class Different extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute must be different with :field";
 
+    /** @var array */
     protected $fillableParams = ['field'];
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
 

--- a/src/Rules/Digits.php
+++ b/src/Rules/Digits.php
@@ -7,11 +7,19 @@ use Rakit\Validation\Rule;
 class Digits extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute must be numeric and must have an exact length of :length";
 
+    /** @var array */
     protected $fillableParams = ['length'];
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
 

--- a/src/Rules/DigitsBetween.php
+++ b/src/Rules/DigitsBetween.php
@@ -7,11 +7,19 @@ use Rakit\Validation\Rule;
 class DigitsBetween extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute must have a length between the given :min and :max";
 
+    /** @var array */
     protected $fillableParams = ['min', 'max'];
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
 

--- a/src/Rules/Email.php
+++ b/src/Rules/Email.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class Email extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute is not valid email";
 
-    public function check($value)
+    /**
+     * Check $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
     }

--- a/src/Rules/FileTrait.php
+++ b/src/Rules/FileTrait.php
@@ -11,6 +11,7 @@ trait FileTrait
      * Check whether value is from $_FILES
      *
      * @param mixed $value
+     * @return mixed
      */
     public function isValueFromUploadedFiles($value)
     {
@@ -28,11 +29,23 @@ trait FileTrait
         return true;
     }
 
-    public function isUploadedFile($value)
+    /**
+     * Check the $value is uploaded file
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function isUploadedFile($value): bool
     {
-        return $this->isValueFromUploadedFiles($value) and is_uploaded_file($value['tmp_name']);
+        return $this->isValueFromUploadedFiles($value) && is_uploaded_file($value['tmp_name']);
     }
 
+    /**
+     * Given $size and get the bytes
+     *
+     * @param mixed $size
+     * @return mixed
+     */
     protected function getBytes($size)
     {
         if (is_int($size)) {

--- a/src/Rules/FileTrait.php
+++ b/src/Rules/FileTrait.php
@@ -11,9 +11,9 @@ trait FileTrait
      * Check whether value is from $_FILES
      *
      * @param mixed $value
-     * @return mixed
+     * @return bool
      */
-    public function isValueFromUploadedFiles($value)
+    public function isValueFromUploadedFiles($value): bool
     {
         if (!is_array($value)) {
             return false;
@@ -43,10 +43,10 @@ trait FileTrait
     /**
      * Given $size and get the bytes
      *
-     * @param mixed $size
-     * @return mixed
+     * @param string|int $size
+     * @return int
      */
-    protected function getBytes($size)
+    protected function getBytes($size): int
     {
         if (is_int($size)) {
             return $size;

--- a/src/Rules/In.php
+++ b/src/Rules/In.php
@@ -45,7 +45,7 @@ class In extends Rule
      * @param mixed $value
      * @return bool
      */
-    public function check($value)
+    public function check($value): bool
     {
         $this->requireParameters(['allowed_values']);
 

--- a/src/Rules/In.php
+++ b/src/Rules/In.php
@@ -7,24 +7,44 @@ use Rakit\Validation\Rule;
 class In extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute is not allowing :value";
 
+    /** @var bool */
     protected $strict = false;
 
-    public function fillParameters(array $params)
+    /**
+     * Given $params and assign the $this->params
+     *
+     * @param array $params
+     * @return self
+     */
+    public function fillParameters(array $params): Rule
     {
-        if (count($params) == 1 and is_array($params[0])) {
+        if (count($params) == 1 && is_array($params[0])) {
             $params = $params[0];
         }
         $this->params['allowed_values'] = $params;
         return $this;
     }
 
-    public function strict($strict = true)
+    /**
+     * Set strict value
+     *
+     * @param bool $strict
+     * @return void
+     */
+    public function strict(bool $strict = true)
     {
         $this->strict = $strict;
     }
 
+    /**
+     * Check $value is existed
+     *
+     * @param mixed $value
+     * @return bool
+     */
     public function check($value)
     {
         $this->requireParameters(['allowed_values']);

--- a/src/Rules/Integer.php
+++ b/src/Rules/Integer.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class Integer extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute must be integer";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         return filter_var($value, FILTER_VALIDATE_INT) !== false;
     }

--- a/src/Rules/Ip.php
+++ b/src/Rules/Ip.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class Ip extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute is not valid IP Address";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         return filter_var($value, FILTER_VALIDATE_IP) !== false;
     }

--- a/src/Rules/Ipv4.php
+++ b/src/Rules/Ipv4.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class Ipv4 extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute is not valid IPv4 Address";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
     }

--- a/src/Rules/Ipv6.php
+++ b/src/Rules/Ipv6.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class Ipv6 extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute is not valid IPv6 Address";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
     }

--- a/src/Rules/Json.php
+++ b/src/Rules/Json.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class Json extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute must be a valid JSON string";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         if (! is_string($value) || empty($value)) {
             return false;

--- a/src/Rules/Lowercase.php
+++ b/src/Rules/Lowercase.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class Lowercase extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute must be lowercase";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         return mb_strtolower($value, mb_detect_encoding($value)) === $value;
     }

--- a/src/Rules/Max.php
+++ b/src/Rules/Max.php
@@ -7,11 +7,19 @@ use Rakit\Validation\Rule;
 class Max extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute maximum is :max";
 
+    /** @var array */
     protected $fillableParams = ['max'];
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
 

--- a/src/Rules/Min.php
+++ b/src/Rules/Min.php
@@ -7,11 +7,19 @@ use Rakit\Validation\Rule;
 class Min extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute minimum is :min";
 
+    /** @var array */
     protected $fillableParams = ['min'];
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
 

--- a/src/Rules/NotIn.php
+++ b/src/Rules/NotIn.php
@@ -7,11 +7,19 @@ use Rakit\Validation\Rule;
 class NotIn extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute is not allowing :value";
 
+    /** @var bool */
     protected $strict = false;
 
-    public function fillParameters(array $params)
+    /**
+     * Given $params and assign the $this->params
+     *
+     * @param array $params
+     * @return self
+     */
+    public function fillParameters(array $params): Rule
     {
         if (count($params) == 1 and is_array($params[0])) {
             $params = $params[0];
@@ -20,12 +28,24 @@ class NotIn extends Rule
         return $this;
     }
 
+    /**
+     * Set strict value
+     *
+     * @param bool $strict
+     * @return void
+     */
     public function strict($strict = true)
     {
         $this->strict = $strict;
     }
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters(['disallowed_values']);
         $disallowedValues = (array) $this->parameter('disallowed_values');

--- a/src/Rules/Numeric.php
+++ b/src/Rules/Numeric.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class Numeric extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute must be numeric";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         return is_numeric($value);
     }

--- a/src/Rules/Present.php
+++ b/src/Rules/Present.php
@@ -6,11 +6,19 @@ use Rakit\Validation\Rule;
 
 class Present extends Rule
 {
+    /** @var bool */
     protected $implicit = true;
 
+    /** @var string */
     protected $message = "The :attribute must be present";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         return $this->validation->hasValue($this->attribute->getKey());
     }

--- a/src/Rules/Regex.php
+++ b/src/Rules/Regex.php
@@ -7,11 +7,19 @@ use Rakit\Validation\Rule;
 class Regex extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute is not valid format";
 
+    /** @var array */
     protected $fillableParams = ['regex'];
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
         $regex = $this->parameter('regex');

--- a/src/Rules/Required.php
+++ b/src/Rules/Required.php
@@ -8,11 +8,19 @@ class Required extends Rule
 {
     use FileTrait;
 
+    /** @var bool */
     protected $implicit = true;
 
+    /** @var string */
     protected $message = "The :attribute is required";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->setAttributeAsRequired();
 
@@ -29,6 +37,11 @@ class Required extends Rule
         return !is_null($value);
     }
 
+    /**
+     * Set attribute is required if $this->attribute is true
+     *
+     * @return void
+     */
     protected function setAttributeAsRequired()
     {
         if ($this->attribute) {

--- a/src/Rules/RequiredIf.php
+++ b/src/Rules/RequiredIf.php
@@ -6,18 +6,32 @@ use Rakit\Validation\Rule;
 
 class RequiredIf extends Required
 {
+    /** @var bool */
     protected $implicit = true;
 
+    /** @var string */
     protected $message = "The :attribute is required";
 
-    public function fillParameters(array $params)
+    /**
+     * Given $params and assign the $this->params
+     *
+     * @param array $params
+     * @return self
+     */
+    public function fillParameters(array $params): Rule
     {
         $this->params['field'] = array_shift($params);
         $this->params['values'] = $params;
         return $this;
     }
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters(['field', 'values']);
 

--- a/src/Rules/RequiredUnless.php
+++ b/src/Rules/RequiredUnless.php
@@ -6,18 +6,32 @@ use Rakit\Validation\Rule;
 
 class RequiredUnless extends Required
 {
+    /** @var bool */
     protected $implicit = true;
 
+    /** @var string */
     protected $message = "The :attribute is required";
 
-    public function fillParameters(array $params)
+    /**
+     * Given $params and assign the $this->params
+     *
+     * @param array $params
+     * @return self
+     */
+    public function fillParameters(array $params): Rule
     {
         $this->params['field'] = array_shift($params);
         $this->params['values'] = $params;
         return $this;
     }
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters(['field', 'values']);
 

--- a/src/Rules/RequiredWith.php
+++ b/src/Rules/RequiredWith.php
@@ -6,17 +6,31 @@ use Rakit\Validation\Rule;
 
 class RequiredWith extends Required
 {
+    /** @var bool */
     protected $implicit = true;
 
+    /** @var string */
     protected $message = "The :attribute is required";
 
-    public function fillParameters(array $params)
+    /**
+     * Given $params and assign $this->params
+     *
+     * @param array $params
+     * @return self
+     */
+    public function fillParameters(array $params): Rule
     {
         $this->params['fields'] = $params;
         return $this;
     }
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters(['fields']);
         $fields = $this->parameter('fields');

--- a/src/Rules/RequiredWithAll.php
+++ b/src/Rules/RequiredWithAll.php
@@ -6,17 +6,31 @@ use Rakit\Validation\Rule;
 
 class RequiredWithAll extends Required
 {
+    /** @var bool */
     protected $implicit = true;
 
+    /** @var string */
     protected $message = "The :attribute is required";
 
-    public function fillParameters(array $params)
+    /**
+     * Given $params and assign $this->params
+     *
+     * @param array $params
+     * @return self
+     */
+    public function fillParameters(array $params): Rule
     {
         $this->params['fields'] = $params;
         return $this;
     }
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters(['fields']);
         $fields = $this->parameter('fields');

--- a/src/Rules/RequiredWithout.php
+++ b/src/Rules/RequiredWithout.php
@@ -6,17 +6,31 @@ use Rakit\Validation\Rule;
 
 class RequiredWithout extends Required
 {
+    /** @var bool */
     protected $implicit = true;
 
+    /** @var string */
     protected $message = "The :attribute is required";
 
-    public function fillParameters(array $params)
+    /**
+     * Given $params and assign $this->params
+     *
+     * @param array $params
+     * @return self
+     */
+    public function fillParameters(array $params): Rule
     {
         $this->params['fields'] = $params;
         return $this;
     }
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters(['fields']);
         $fields = $this->parameter('fields');

--- a/src/Rules/RequiredWithoutAll.php
+++ b/src/Rules/RequiredWithoutAll.php
@@ -6,17 +6,31 @@ use Rakit\Validation\Rule;
 
 class RequiredWithoutAll extends Required
 {
+    /** @var bool */
     protected $implicit = true;
 
+    /** @var string */
     protected $message = "The :attribute is required";
 
-    public function fillParameters(array $params)
+    /**
+     * Given $params and assign $this->params
+     *
+     * @param array $params
+     * @return self
+     */
+    public function fillParameters(array $params): Rule
     {
         $this->params['fields'] = $params;
         return $this;
     }
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters(['fields']);
         $fields = $this->parameter('fields');

--- a/src/Rules/Same.php
+++ b/src/Rules/Same.php
@@ -7,11 +7,19 @@ use Rakit\Validation\Rule;
 class Same extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute must be same with :field";
 
+    /** @var array */
     protected $fillableParams = ['field'];
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $this->requireParameters($this->fillableParams);
 

--- a/src/Rules/TypeArray.php
+++ b/src/Rules/TypeArray.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class TypeArray extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute must be array";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         return is_array($value);
     }

--- a/src/Rules/UploadedFile.php
+++ b/src/Rules/UploadedFile.php
@@ -12,10 +12,10 @@ class UploadedFile extends Rule
     /** @var string */
     protected $message = "The :attribute is not valid";
 
-    /** @var mixed */
+    /** @var string|int */
     protected $maxSize = null;
 
-    /** @var mixed */
+    /** @var string|int */
     protected $minSize = null;
 
     /** @var array */
@@ -25,7 +25,7 @@ class UploadedFile extends Rule
      * Given $params and assign $this->params
      *
      * @param array $params
-     * @return Rule
+     * @return self
      */
     public function fillParameters(array $params): Rule
     {
@@ -39,10 +39,10 @@ class UploadedFile extends Rule
     /**
      * Given $size and set the max size
      *
-     * @param mixed $size
-     * @return Rule
+     * @param string|int $size
+     * @return self
      */
-    public function maxSize($size)
+    public function maxSize($size): Rule
     {
         $this->params['max_size'] = $size;
         return $this;
@@ -51,10 +51,10 @@ class UploadedFile extends Rule
     /**
      * Given $size and set the min size
      *
-     * @param mixed $size
-     * @return Rule
+     * @param string|int $size
+     * @return self
      */
-    public function minSize($size)
+    public function minSize($size): Rule
     {
         $this->params['min_size'] = $size;
         return $this;
@@ -63,11 +63,11 @@ class UploadedFile extends Rule
     /**
      * Given $min and $max then set the range size
      *
-     * @param mixed $min
-     * @param mixed $max
-     * @return Rule
+     * @param string|int $min
+     * @param string|int $max
+     * @return self
      */
-    public function sizeBetween($min, $max)
+    public function sizeBetween($min, $max): Rule
     {
         $this->minSize($min);
         $this->maxSize($max);
@@ -79,9 +79,9 @@ class UploadedFile extends Rule
      * Given $types and assign $this->params
      *
      * @param mixed $types
-     * @return Rule
+     * @return self
      */
-    public function fileTypes($types)
+    public function fileTypes($types): Rule
     {
         if (is_string($types)) {
             $types = explode('|', $types);

--- a/src/Rules/UploadedFile.php
+++ b/src/Rules/UploadedFile.php
@@ -9,13 +9,25 @@ class UploadedFile extends Rule
 {
     use FileTrait;
 
+    /** @var string */
     protected $message = "The :attribute is not valid";
 
+    /** @var mixed */
     protected $maxSize = null;
+
+    /** @var mixed */
     protected $minSize = null;
+
+    /** @var array */
     protected $allowedTypes = [];
 
-    public function fillParameters(array $params)
+    /**
+     * Given $params and assign $this->params
+     *
+     * @param array $params
+     * @return Rule
+     */
+    public function fillParameters(array $params): Rule
     {
         $this->minSize(array_shift($params));
         $this->maxSize(array_shift($params));
@@ -24,18 +36,37 @@ class UploadedFile extends Rule
         return $this;
     }
 
+    /**
+     * Given $size and set the max size
+     *
+     * @param mixed $size
+     * @return Rule
+     */
     public function maxSize($size)
     {
         $this->params['max_size'] = $size;
         return $this;
     }
 
+    /**
+     * Given $size and set the min size
+     *
+     * @param mixed $size
+     * @return Rule
+     */
     public function minSize($size)
     {
         $this->params['min_size'] = $size;
         return $this;
     }
 
+    /**
+     * Given $min and $max then set the range size
+     *
+     * @param mixed $min
+     * @param mixed $max
+     * @return Rule
+     */
     public function sizeBetween($min, $max)
     {
         $this->minSize($min);
@@ -44,6 +75,12 @@ class UploadedFile extends Rule
         return $this;
     }
 
+    /**
+     * Given $types and assign $this->params
+     *
+     * @param mixed $types
+     * @return Rule
+     */
     public function fileTypes($types)
     {
         if (is_string($types)) {
@@ -55,7 +92,13 @@ class UploadedFile extends Rule
         return $this;
     }
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $minSize = $this->parameter('min_size');
         $maxSize = $this->parameter('max_size');

--- a/src/Rules/Uppercase.php
+++ b/src/Rules/Uppercase.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class Uppercase extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute must be uppercase";
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         return mb_strtoupper($value, mb_detect_encoding($value)) === $value;
     }

--- a/src/Rules/Url.php
+++ b/src/Rules/Url.php
@@ -7,9 +7,16 @@ use Rakit\Validation\Rule;
 class Url extends Rule
 {
 
+    /** @var string */
     protected $message = "The :attribute is not valid url";
 
-    public function fillParameters(array $params)
+    /**
+     * Given $params and assign $this->params
+     *
+     * @param array $params
+     * @return self
+     */
+    public function fillParameters(array $params): Rule
     {
         if (count($params) == 1 and is_array($params[0])) {
             $params = $params[0];
@@ -17,13 +24,25 @@ class Url extends Rule
         return $this->forScheme($params);
     }
 
-    public function forScheme($schemes)
+    /**
+     * Given $schemes and assign $this->params
+     *
+     * @param array $schemes
+     * @return self
+     */
+    public function forScheme($schemes): self
     {
         $this->params['schemes'] = (array) $schemes;
         return $this;
     }
 
-    public function check($value)
+    /**
+     * Check the $value is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
     {
         $schemes = $this->parameter('schemes');
 
@@ -45,12 +64,25 @@ class Url extends Rule
         }
     }
 
-    public function validateBasic($value)
+    /**
+     * Validate $value is valid URL format
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validateBasic($value): bool
     {
         return filter_var($value, FILTER_VALIDATE_URL) !== false;
     }
 
-    public function validateCommonScheme($value, $scheme = null)
+    /**
+     * Validate $value is correct $scheme format
+     *
+     * @param mixed $value
+     * @param null $scheme
+     * @return bool
+     */
+    public function validateCommonScheme($value, $scheme = null): bool
     {
         if (!$scheme) {
             return $this->validateBasic($value) && (bool) preg_match("/^\w+:\/\//i", $value);
@@ -59,12 +91,24 @@ class Url extends Rule
         }
     }
 
-    public function validateMailtoScheme($value)
+    /**
+     * Validate the $value is mailto scheme format
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validateMailtoScheme($value): bool
     {
         return $this->validateBasic($value) && preg_match("/^mailto:/", $value);
     }
 
-    public function validateJdbcScheme($value)
+    /**
+     * Validate the $value is jdbc scheme format
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validateJdbcScheme($value): bool
     {
         return (bool) preg_match("/^jdbc:\w+:\/\//", $value);
     }

--- a/src/Rules/Url.php
+++ b/src/Rules/Url.php
@@ -30,7 +30,7 @@ class Url extends Rule
      * @param array $schemes
      * @return self
      */
-    public function forScheme($schemes): self
+    public function forScheme($schemes): Rule
     {
         $this->params['schemes'] = (array) $schemes;
         return $this;

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -42,8 +42,12 @@ class Validation
      * @param array $messages
      * @return void
      */
-    public function __construct(Validator $validator, array $inputs, array $rules, array $messages = [])
-    {
+    public function __construct(
+        Validator $validator,
+        array $inputs,
+        array $rules,
+        array $messages = []
+    ) {
         $this->validator = $validator;
         $this->inputs = $this->resolveInputAttributes($inputs);
         $this->messages = $messages;
@@ -54,13 +58,13 @@ class Validation
     }
 
     /**
-     * Add attribute key and rules
+     * Add attribute rules
      *
-     * @param mixed $attributeKey
-     * @param mixed $rules
+     * @param string $attributeKey
+     * @param string|array $rules
      * @return void
      */
-    public function addAttribute($attributeKey, $rules)
+    public function addAttribute(string $attributeKey, $rules): void
     {
         $resolvedRules = $this->resolveRules($rules);
         $attribute = new Attribute($this, $attributeKey, $this->getAlias($attributeKey), $resolvedRules);
@@ -68,23 +72,23 @@ class Validation
     }
 
     /**
-     * Given $attributeKey and get attribute
+     * Get attribute by key
      *
-     * @param mixed $attributeKey
-     * @return void
+     * @param string $attributeKey
+     * @return null|Rakit\Validation\Attribute
      */
-    public function getAttribute($attributeKey)
+    public function getAttribute(string $attributeKey)
     {
         return isset($this->attributes[$attributeKey])? $this->attributes[$attributeKey] : null;
     }
 
     /**
-     * Validate attributes in given $inputs
+     * Run validation
      *
      * @param array $inputs
      * @return void
      */
-    public function validate(array $inputs = [])
+    public function validate(array $inputs = []): void
     {
         $this->errors = new ErrorBag; // reset error bag
         $this->inputs = array_merge($this->inputs, $this->resolveInputAttributes($inputs));
@@ -94,9 +98,9 @@ class Validation
     }
 
     /**
-     * Get $this->errors
+     * Get ErrorBag instance
      *
-     * @return ErrorBag
+     * @return Rakit\Validation\ErrorBag
      */
     public function errors(): ErrorBag
     {
@@ -104,12 +108,12 @@ class Validation
     }
 
     /**
-     * Validate attributes
+     * Validate attribute
      *
-     * @param Attribute $attribute
+     * @param Rakit\Validation\Attribute $attribute
      * @return void
      */
-    protected function validateAttribute(Attribute $attribute)
+    protected function validateAttribute(Attribute $attribute): void
     {
         if ($this->isArrayAttribute($attribute)) {
             $attributes = $this->parseArrayAttribute($attribute);
@@ -158,9 +162,9 @@ class Validation
     }
 
     /**
-     * Check the $attribute is array $attribute
+     * Check whether given $attribute is array attribute
      *
-     * @param Attribute $attribute
+     * @param Rakit\Validation\Attribute $attribute
      * @return bool
      */
     protected function isArrayAttribute(Attribute $attribute): bool
@@ -170,9 +174,9 @@ class Validation
     }
 
     /**
-     * Parse array $attribute
+     * Parse array attribute into it's child attributes
      *
-     * @param Attribute $attribute
+     * @param Rakit\Validation\Attribute $attribute
      * @return array
      */
     protected function parseArrayAttribute(Attribute $attribute): array
@@ -215,7 +219,7 @@ class Validation
      * @param  string  $attribute
      * @return array
      */
-    protected function initializeAttributeOnData($attributeKey)
+    protected function initializeAttributeOnData(string $attributeKey): array
     {
         $explicitPath = $this->getLeadingExplicitAttributePath($attributeKey);
 
@@ -238,7 +242,7 @@ class Validation
      * @param  string  $attributeKey
      * @return array
      */
-    public function extractValuesForWildcards($data, $attributeKey)
+    public function extractValuesForWildcards(array $data, string $attributeKey): array
     {
         $keys = [];
 
@@ -272,7 +276,7 @@ class Validation
      * @param  string  $attributeKey
      * @return string
      */
-    protected function getLeadingExplicitAttributePath($attributeKey)
+    protected function getLeadingExplicitAttributePath(string $attributeKey): string
     {
         return rtrim(explode('*', $attributeKey)[0], '.') ?: null;
     }
@@ -286,7 +290,7 @@ class Validation
      * @param  string  $attributeKey
      * @return array
      */
-    protected function extractDataFromPath($attributeKey)
+    protected function extractDataFromPath(string $attributeKey): array
     {
         $results = [];
 
@@ -302,12 +306,12 @@ class Validation
     /**
      * Add error to the $this->errors
      *
-     * @param Attribute $attribute
+     * @param Rakit\Validation\Attribute $attribute
      * @param mixed $value
-     * @param Rule $ruleValidator
+     * @param Rakit\Validation\Rule $ruleValidator
      * @return void
      */
-    protected function addError(Attribute $attribute, $value, Rule $ruleValidator)
+    protected function addError(Attribute $attribute, $value, Rule $ruleValidator): void
     {
         $ruleName = $ruleValidator->getKey();
         $message = $this->resolveMessage($attribute, $value, $ruleValidator);
@@ -321,7 +325,7 @@ class Validation
      * @param mixed $value
      * @return boolean
      */
-    protected function isEmptyValue($value)
+    protected function isEmptyValue($value): bool
     {
         $requiredValidator = new Required;
         return false === $requiredValidator->check($value, []);
@@ -330,11 +334,11 @@ class Validation
     /**
      * Check the rule is optional
      *
-     * @param Attribute $attribute
-     * @param Rule $rule
+     * @param Rakit\Validation\Attribute $attribute
+     * @param Rakit\Validation\Rule $rule
      * @return bool
      */
-    protected function ruleIsOptional(Attribute $attribute, Rule $rule)
+    protected function ruleIsOptional(Attribute $attribute, Rule $rule): bool
     {
         return false === $attribute->isRequired() and
             false === $rule->isImplicit() and
@@ -344,17 +348,17 @@ class Validation
     /**
      * Resolve attribute name
      *
-     * @param Attribute $attribute
-     * @return mixed
+     * @param Rakit\Validation\Attribute $attribute
+     * @return string
      */
-    protected function resolveAttributeName(Attribute $attribute)
+    protected function resolveAttributeName(Attribute $attribute): string
     {
         $primaryAttribute = $attribute->getPrimaryAttribute();
         if (isset($this->aliases[$attribute->getKey()])) {
             return $this->aliases[$attribute->getKey()];
         } elseif ($primaryAttribute and isset($this->aliases[$primaryAttribute->getKey()])) {
             return $this->aliases[$primaryAttribute->getKey()];
-        } elseif ($this->validator->getUseHumanizedKeys()) {
+        } elseif ($this->validator->isUsingHumanizedKey()) {
             return $attribute->getHumanizedKey();
         } else {
             return $attribute->getKey();
@@ -364,12 +368,12 @@ class Validation
     /**
      * Resolve message
      *
-     * @param Attribute $attribute
+     * @param Rakit\Validation\Attribute $attribute
      * @param mixed $value
-     * @param Rule $validator
+     * @param Rakit\Validation\Rule $validator
      * @return mixed
      */
-    protected function resolveMessage(Attribute $attribute, $value, Rule $validator)
+    protected function resolveMessage(Attribute $attribute, $value, Rule $validator): string
     {
         $primaryAttribute = $attribute->getPrimaryAttribute();
         $params = $validator->getParameters();
@@ -436,9 +440,9 @@ class Validation
      * Stringify $value
      *
      * @param mixed $value
-     * @return mixed
+     * @return string
      */
-    protected function stringify($value)
+    protected function stringify($value): string
     {
         if (is_string($value) || is_numeric($value)) {
             return $value;
@@ -455,7 +459,7 @@ class Validation
      * @param mixed $rules
      * @return array
      */
-    protected function resolveRules($rules)
+    protected function resolveRules($rules): array
     {
         if (is_string($rules)) {
             $rules = explode('|', $rules);
@@ -491,10 +495,10 @@ class Validation
     /**
      * Parse $rule
      *
-     * @param mixed $rule
+     * @param string $rule
      * @return array
      */
-    protected function parseRule($rule)
+    protected function parseRule(string $rule): array
     {
         $exp = explode(':', $rule, 2);
         $rulename = $exp[0];
@@ -514,18 +518,18 @@ class Validation
      * @param mixed $message
      * @return void
      */
-    public function setMessage($key, $message)
+    public function setMessage(string $key, string $message): void
     {
         $this->messages[$key] = $message;
     }
 
     /**
-     * Set messages
+     * Set multiple messages
      *
      * @param array $messages
      * @return void
      */
-    public function setMessages(array $messages)
+    public function setMessages(array $messages): void
     {
         $this->messages = array_merge($this->messages, $messages);
     }
@@ -537,29 +541,29 @@ class Validation
      * @param mixed $alias
      * @return void
      */
-    public function setAlias($attributeKey, $alias)
+    public function setAlias(string $attributeKey, string $alias): void
     {
         $this->aliases[$attributeKey] = $alias;
     }
 
     /**
-     * Given $attributeKey and get alias
+     * Get attribute alias from given key
      *
      * @param mixed $attributeKey
-     * @return void
+     * @return string|null
      */
-    public function getAlias($attributeKey)
+    public function getAlias(string $attributeKey)
     {
         return isset($this->aliases[$attributeKey])? $this->aliases[$attributeKey] : null;
     }
 
     /**
-     * Given $aliases then set aliases
+     * Set attributes aliases
      *
-     * @param [type] $aliases
+     * @param array $aliases
      * @return void
      */
-    public function setAliases(array $aliases)
+    public function setAliases(array $aliases): void
     {
         $this->aliases = array_merge($this->aliases, $aliases);
     }
@@ -569,7 +573,7 @@ class Validation
      *
      * @return bool
      */
-    public function passes()
+    public function passes(): bool
     {
         return $this->errors->count() == 0;
     }
@@ -579,7 +583,7 @@ class Validation
      *
      * @return bool
      */
-    public function fails()
+    public function fails(): bool
     {
         return !$this->passes();
     }
@@ -587,10 +591,10 @@ class Validation
     /**
      * Given $key and get value
      *
-     * @param mixed $key
-     * @return void
+     * @param string $key
+     * @return mixed
      */
-    public function getValue($key)
+    public function getValue(string $key)
     {
         return Helper::arrayGet($this->inputs, $key);
     }
@@ -598,10 +602,10 @@ class Validation
     /**
      * Given $key and check value is exsited
      *
-     * @param mixed $key
+     * @param string $key
      * @return boolean
      */
-    public function hasValue($key)
+    public function hasValue(string $key): bool
     {
         return Helper::arrayHas($this->inputs, $key);
     }
@@ -609,9 +613,9 @@ class Validation
     /**
      * Get Validator class instance
      *
-     * @return Validator
+     * @return Rakit\Validation\Validator
      */
-    public function getValidator()
+    public function getValidator(): Validator
     {
         return $this->validator;
     }
@@ -622,7 +626,7 @@ class Validation
      * @param array $inputs
      * @return array
      */
-    protected function resolveInputAttributes(array $inputs)
+    protected function resolveInputAttributes(array $inputs): array
     {
         $resolvedInputs = [];
         foreach ($inputs as $key => $rules) {
@@ -644,7 +648,7 @@ class Validation
      *
      * @return array
      */
-    public function getValidatedData()
+    public function getValidatedData(): array
     {
         return array_merge($this->validData, $this->invalidData);
     }
@@ -652,11 +656,11 @@ class Validation
     /**
      * Set valid data
      *
-     * @param Attribute $attribute
+     * @param Rakit\Validation\Attribute $attribute
      * @param mixed $value
      * @return void
      */
-    protected function setValidData(Attribute $attribute, $value)
+    protected function setValidData(Attribute $attribute, $value): void
     {
         $key = $attribute->getKey();
         if ($attribute->isArrayAttribute() || $attribute->isUsingDotNotation()) {
@@ -672,7 +676,7 @@ class Validation
      *
      * @return array
      */
-    public function getValidData()
+    public function getValidData(): array
     {
         return $this->validData;
     }
@@ -680,11 +684,11 @@ class Validation
     /**
      * Set invalid data
      *
-     * @param Attribute $attribute
+     * @param Rakit\Validation\Attribute $attribute
      * @param mixed $value
      * @return void
      */
-    protected function setInvalidData(Attribute $attribute, $value)
+    protected function setInvalidData(Attribute $attribute, $value): void
     {
         $key = $attribute->getKey();
         if ($attribute->isArrayAttribute() || $attribute->isUsingDotNotation()) {
@@ -700,7 +704,7 @@ class Validation
      *
      * @return void
      */
-    public function getInvalidData()
+    public function getInvalidData(): array
     {
         return $this->invalidData;
     }

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -64,7 +64,7 @@ class Validation
      * @param string|array $rules
      * @return void
      */
-    public function addAttribute(string $attributeKey, $rules): void
+    public function addAttribute(string $attributeKey, $rules)
     {
         $resolvedRules = $this->resolveRules($rules);
         $attribute = new Attribute($this, $attributeKey, $this->getAlias($attributeKey), $resolvedRules);
@@ -88,7 +88,7 @@ class Validation
      * @param array $inputs
      * @return void
      */
-    public function validate(array $inputs = []): void
+    public function validate(array $inputs = [])
     {
         $this->errors = new ErrorBag; // reset error bag
         $this->inputs = array_merge($this->inputs, $this->resolveInputAttributes($inputs));
@@ -113,7 +113,7 @@ class Validation
      * @param Rakit\Validation\Attribute $attribute
      * @return void
      */
-    protected function validateAttribute(Attribute $attribute): void
+    protected function validateAttribute(Attribute $attribute)
     {
         if ($this->isArrayAttribute($attribute)) {
             $attributes = $this->parseArrayAttribute($attribute);
@@ -311,7 +311,7 @@ class Validation
      * @param Rakit\Validation\Rule $ruleValidator
      * @return void
      */
-    protected function addError(Attribute $attribute, $value, Rule $ruleValidator): void
+    protected function addError(Attribute $attribute, $value, Rule $ruleValidator)
     {
         $ruleName = $ruleValidator->getKey();
         $message = $this->resolveMessage($attribute, $value, $ruleValidator);
@@ -518,7 +518,7 @@ class Validation
      * @param mixed $message
      * @return void
      */
-    public function setMessage(string $key, string $message): void
+    public function setMessage(string $key, string $message)
     {
         $this->messages[$key] = $message;
     }
@@ -529,7 +529,7 @@ class Validation
      * @param array $messages
      * @return void
      */
-    public function setMessages(array $messages): void
+    public function setMessages(array $messages)
     {
         $this->messages = array_merge($this->messages, $messages);
     }
@@ -541,7 +541,7 @@ class Validation
      * @param mixed $alias
      * @return void
      */
-    public function setAlias(string $attributeKey, string $alias): void
+    public function setAlias(string $attributeKey, string $alias)
     {
         $this->aliases[$attributeKey] = $alias;
     }
@@ -563,7 +563,7 @@ class Validation
      * @param array $aliases
      * @return void
      */
-    public function setAliases(array $aliases): void
+    public function setAliases(array $aliases)
     {
         $this->aliases = array_merge($this->aliases, $aliases);
     }
@@ -660,7 +660,7 @@ class Validation
      * @param mixed $value
      * @return void
      */
-    protected function setValidData(Attribute $attribute, $value): void
+    protected function setValidData(Attribute $attribute, $value)
     {
         $key = $attribute->getKey();
         if ($attribute->isArrayAttribute() || $attribute->isUsingDotNotation()) {
@@ -688,7 +688,7 @@ class Validation
      * @param mixed $value
      * @return void
      */
-    protected function setInvalidData(Attribute $attribute, $value): void
+    protected function setInvalidData(Attribute $attribute, $value)
     {
         $key = $attribute->getKey();
         if ($attribute->isArrayAttribute() || $attribute->isUsingDotNotation()) {

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -36,7 +36,7 @@ class Validation
     /**
      * Constructor
      *
-     * @param Validator $validator
+     * @param Rakit\Validation\Validator $validator
      * @param array $inputs
      * @param array $rules
      * @param array $messages

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -9,22 +9,40 @@ use Rakit\Validation\Rules\Defaults;
 class Validation
 {
 
+    /** @var mixed */
     protected $validator;
 
+    /** @var array */
     protected $inputs = [];
 
+    /** @var array */
     protected $attributes = [];
 
+    /** @var array */
     protected $messages = [];
 
+    /** @var array */
     protected $aliases = [];
 
+    /** @var string */
     protected $messageSeparator = ':';
 
+    /** @var array */
     protected $validData = [];
+
+    /** @var array */
     protected $invalidData = [];
 
-    public function __construct(Validator $validator, array $inputs, array $rules, array $messages = array())
+    /**
+     * Constructor
+     *
+     * @param Validator $validator
+     * @param array $inputs
+     * @param array $rules
+     * @param array $messages
+     * @return void
+     */
+    public function __construct(Validator $validator, array $inputs, array $rules, array $messages = [])
     {
         $this->validator = $validator;
         $this->inputs = $this->resolveInputAttributes($inputs);
@@ -35,6 +53,13 @@ class Validation
         }
     }
 
+    /**
+     * Add attribute key and rules
+     *
+     * @param mixed $attributeKey
+     * @param mixed $rules
+     * @return void
+     */
     public function addAttribute($attributeKey, $rules)
     {
         $resolvedRules = $this->resolveRules($rules);
@@ -42,12 +67,24 @@ class Validation
         $this->attributes[$attributeKey] = $attribute;
     }
 
+    /**
+     * Given $attributeKey and get attribute
+     *
+     * @param mixed $attributeKey
+     * @return void
+     */
     public function getAttribute($attributeKey)
     {
         return isset($this->attributes[$attributeKey])? $this->attributes[$attributeKey] : null;
     }
 
-    public function validate(array $inputs = array())
+    /**
+     * Validate attributes in given $inputs
+     *
+     * @param array $inputs
+     * @return void
+     */
+    public function validate(array $inputs = [])
     {
         $this->errors = new ErrorBag; // reset error bag
         $this->inputs = array_merge($this->inputs, $this->resolveInputAttributes($inputs));
@@ -56,11 +93,22 @@ class Validation
         }
     }
 
-    public function errors()
+    /**
+     * Get $this->errors
+     *
+     * @return ErrorBag
+     */
+    public function errors(): ErrorBag
     {
         return $this->errors;
     }
 
+    /**
+     * Validate attributes
+     *
+     * @param Attribute $attribute
+     * @return void
+     */
     protected function validateAttribute(Attribute $attribute)
     {
         if ($this->isArrayAttribute($attribute)) {
@@ -109,13 +157,25 @@ class Validation
         }
     }
 
-    protected function isArrayAttribute(Attribute $attribute)
+    /**
+     * Check the $attribute is array $attribute
+     *
+     * @param Attribute $attribute
+     * @return bool
+     */
+    protected function isArrayAttribute(Attribute $attribute): bool
     {
         $key = $attribute->getKey();
         return strpos($key, '*') !== false;
     }
 
-    protected function parseArrayAttribute(Attribute $attribute)
+    /**
+     * Parse array $attribute
+     *
+     * @param Attribute $attribute
+     * @return array
+     */
+    protected function parseArrayAttribute(Attribute $attribute): array
     {
         $attributeKey = $attribute->getKey();
         $data = Helper::arrayDot($this->initializeAttributeOnData($attributeKey));
@@ -239,6 +299,14 @@ class Validation
         return $results;
     }
 
+    /**
+     * Add error to the $this->errors
+     *
+     * @param Attribute $attribute
+     * @param mixed $value
+     * @param Rule $ruleValidator
+     * @return void
+     */
     protected function addError(Attribute $attribute, $value, Rule $ruleValidator)
     {
         $ruleName = $ruleValidator->getKey();
@@ -247,12 +315,25 @@ class Validation
         $this->errors->add($attribute->getKey(), $ruleName, $message);
     }
 
+    /**
+     * Check $value is empty value
+     *
+     * @param mixed $value
+     * @return boolean
+     */
     protected function isEmptyValue($value)
     {
         $requiredValidator = new Required;
         return false === $requiredValidator->check($value, []);
     }
 
+    /**
+     * Check the rule is optional
+     *
+     * @param Attribute $attribute
+     * @param Rule $rule
+     * @return bool
+     */
     protected function ruleIsOptional(Attribute $attribute, Rule $rule)
     {
         return false === $attribute->isRequired() and
@@ -260,6 +341,12 @@ class Validation
             false === $rule instanceof Required;
     }
 
+    /**
+     * Resolve attribute name
+     *
+     * @param Attribute $attribute
+     * @return mixed
+     */
     protected function resolveAttributeName(Attribute $attribute)
     {
         $primaryAttribute = $attribute->getPrimaryAttribute();
@@ -274,6 +361,14 @@ class Validation
         }
     }
 
+    /**
+     * Resolve message
+     *
+     * @param Attribute $attribute
+     * @param mixed $value
+     * @param Rule $validator
+     * @return mixed
+     */
     protected function resolveMessage(Attribute $attribute, $value, Rule $validator)
     {
         $primaryAttribute = $attribute->getPrimaryAttribute();
@@ -337,6 +432,12 @@ class Validation
         return $message;
     }
 
+    /**
+     * Stringify $value
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     protected function stringify($value)
     {
         if (is_string($value) || is_numeric($value)) {
@@ -348,6 +449,12 @@ class Validation
         }
     }
 
+    /**
+     * Resolve $rules
+     *
+     * @param mixed $rules
+     * @return array
+     */
     protected function resolveRules($rules)
     {
         if (is_string($rules)) {
@@ -381,6 +488,12 @@ class Validation
         return $resolvedRules;
     }
 
+    /**
+     * Parse $rule
+     *
+     * @param mixed $rule
+     * @return array
+     */
     protected function parseRule($rule)
     {
         $exp = explode(':', $rule, 2);
@@ -394,56 +507,121 @@ class Validation
         return [$rulename, $params];
     }
 
+    /**
+     * Set message
+     *
+     * @param mixed $key
+     * @param mixed $message
+     * @return void
+     */
     public function setMessage($key, $message)
     {
         $this->messages[$key] = $message;
     }
 
+    /**
+     * Set messages
+     *
+     * @param array $messages
+     * @return void
+     */
     public function setMessages(array $messages)
     {
         $this->messages = array_merge($this->messages, $messages);
     }
 
+    /**
+     * Given $attributeKey and $alias then assign alias
+     *
+     * @param mixed $attributeKey
+     * @param mixed $alias
+     * @return void
+     */
     public function setAlias($attributeKey, $alias)
     {
         $this->aliases[$attributeKey] = $alias;
     }
 
+    /**
+     * Given $attributeKey and get alias
+     *
+     * @param mixed $attributeKey
+     * @return void
+     */
     public function getAlias($attributeKey)
     {
         return isset($this->aliases[$attributeKey])? $this->aliases[$attributeKey] : null;
     }
 
-    public function setAliases($aliases)
+    /**
+     * Given $aliases then set aliases
+     *
+     * @param [type] $aliases
+     * @return void
+     */
+    public function setAliases(array $aliases)
     {
         $this->aliases = array_merge($this->aliases, $aliases);
     }
 
+    /**
+     * Check validations are passed
+     *
+     * @return bool
+     */
     public function passes()
     {
         return $this->errors->count() == 0;
     }
 
+    /**
+     * Check validations are failed
+     *
+     * @return bool
+     */
     public function fails()
     {
         return !$this->passes();
     }
 
+    /**
+     * Given $key and get value
+     *
+     * @param mixed $key
+     * @return void
+     */
     public function getValue($key)
     {
         return Helper::arrayGet($this->inputs, $key);
     }
 
+    /**
+     * Given $key and check value is exsited
+     *
+     * @param mixed $key
+     * @return boolean
+     */
     public function hasValue($key)
     {
         return Helper::arrayHas($this->inputs, $key);
     }
 
+    /**
+     * Get Validator class instance
+     *
+     * @return Validator
+     */
     public function getValidator()
     {
         return $this->validator;
     }
 
+    /**
+     * Given $inputs and resolve input attributes
+     *
+     * @param array $inputs
+     * @return array
+     */
     protected function resolveInputAttributes(array $inputs)
     {
         $resolvedInputs = [];
@@ -461,11 +639,23 @@ class Validation
         return $resolvedInputs;
     }
 
+    /**
+     * Get validated data
+     *
+     * @return array
+     */
     public function getValidatedData()
     {
         return array_merge($this->validData, $this->invalidData);
     }
 
+    /**
+     * Set valid data
+     *
+     * @param Attribute $attribute
+     * @param mixed $value
+     * @return void
+     */
     protected function setValidData(Attribute $attribute, $value)
     {
         $key = $attribute->getKey();
@@ -477,11 +667,23 @@ class Validation
         }
     }
 
+    /**
+     * Get valid data
+     *
+     * @return array
+     */
     public function getValidData()
     {
         return $this->validData;
     }
 
+    /**
+     * Set invalid data
+     *
+     * @param Attribute $attribute
+     * @param mixed $value
+     * @return void
+     */
     protected function setInvalidData(Attribute $attribute, $value)
     {
         $key = $attribute->getKey();
@@ -493,6 +695,11 @@ class Validation
         }
     }
 
+    /**
+     * Get invalid data
+     *
+     * @return void
+     */
     public function getInvalidData()
     {
         return $this->invalidData;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -36,9 +36,9 @@ class Validator
      * @param mixed $message
      * @return void
      */
-    public function setMessage($key, $message)
+    public function setMessage(string $key, string $message): void
     {
-        return $this->messages[$key] = $message;
+        $this->messages[$key] = $message;
     }
 
     /**
@@ -47,26 +47,26 @@ class Validator
      * @param array $messages
      * @return void
      */
-    public function setMessages($messages)
+    public function setMessages(array $messages): void
     {
         $this->messages = array_merge($this->messages, $messages);
     }
 
     /**
-     * Given $key and $rule to ser validator
+     * Register or override existing validator
      *
      * @param mixed $key
      * @param Rule $rule
      * @return void
      */
-    public function setValidator($key, Rule $rule)
+    public function setValidator(string $key, Rule $rule): void
     {
         $this->validators[$key] = $rule;
         $rule->setKey($key);
     }
 
     /**
-     * Given $key to get validator
+     * Get validator object from given $key
      *
      * @param mixed $key
      * @return mixed
@@ -84,7 +84,7 @@ class Validator
      * @param array $messages
      * @return Validation
      */
-    public function validate(array $inputs, array $rules, array $messages = [])
+    public function validate(array $inputs, array $rules, array $messages = []): Validation
     {
         $validation = $this->make($inputs, $rules, $messages);
         $validation->validate();
@@ -99,20 +99,20 @@ class Validator
      * @param array $messages
      * @return Validation
      */
-    public function make(array $inputs, array $rules, array $messages = [])
+    public function make(array $inputs, array $rules, array $messages = []): Validation
     {
         $messages = array_merge($this->messages, $messages);
         return new Validation($this, $inputs, $rules, $messages);
     }
 
     /**
-     * magic invoke method
+     * Magic invoke method to make Rule instance
      *
-     * @param mixed $rule
-     * @return mixed
+     * @param string $rule
+     * @return Rule
      * @throws RuleNotFoundException
      */
-    public function __invoke($rule)
+    public function __invoke(string $rule): Rule
     {
         $args = func_get_args();
         $rule = array_shift($args);
@@ -133,7 +133,7 @@ class Validator
      *
      * @return void
      */
-    protected function registerBaseValidators()
+    protected function registerBaseValidators(): void
     {
         $baseValidator = [
             'required'                  => new Rules\Required,
@@ -184,13 +184,13 @@ class Validator
     }
 
     /**
-     * Given $ruleName and $rule to sdd new validator
+     * Given $ruleName and $rule to add new validator
      *
-     * @param mixed $ruleName
+     * @param string $ruleName
      * @param Rule $rule
      * @return void
      */
-    public function addValidator($ruleName, Rule $rule)
+    public function addValidator(string $ruleName, Rule $rule): void
     {
         if (!$this->allowRuleOverride && array_key_exists($ruleName, $this->validators)) {
             throw new RuleQuashException(
@@ -207,7 +207,7 @@ class Validator
      * @param boolean $status
      * @return void
      */
-    public function allowRuleOverride($status = false)
+    public function allowRuleOverride(bool $status = false): void
     {
         $this->allowRuleOverride = $status;
     }
@@ -218,7 +218,7 @@ class Validator
      * @param boolean $useHumanizedKeys
      * @return void
      */
-    public function setUseHumanizedKeys($useHumanizedKeys = true)
+    public function setUseHumanizedKeys(bool $useHumanizedKeys = true): void
     {
         $this->useHumanizedKeys = $useHumanizedKeys;
     }
@@ -228,7 +228,7 @@ class Validator
      *
      * @return void
      */
-    public function getUseHumanizedKeys()
+    public function isUsingHumanizedKey(): bool
     {
         return $this->useHumanizedKeys;
     }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -36,7 +36,7 @@ class Validator
      * @param mixed $message
      * @return void
      */
-    public function setMessage(string $key, string $message): void
+    public function setMessage(string $key, string $message)
     {
         $this->messages[$key] = $message;
     }
@@ -47,7 +47,7 @@ class Validator
      * @param array $messages
      * @return void
      */
-    public function setMessages(array $messages): void
+    public function setMessages(array $messages)
     {
         $this->messages = array_merge($this->messages, $messages);
     }
@@ -59,7 +59,7 @@ class Validator
      * @param Rule $rule
      * @return void
      */
-    public function setValidator(string $key, Rule $rule): void
+    public function setValidator(string $key, Rule $rule)
     {
         $this->validators[$key] = $rule;
         $rule->setKey($key);
@@ -133,7 +133,7 @@ class Validator
      *
      * @return void
      */
-    protected function registerBaseValidators(): void
+    protected function registerBaseValidators()
     {
         $baseValidator = [
             'required'                  => new Rules\Required,
@@ -190,7 +190,7 @@ class Validator
      * @param Rule $rule
      * @return void
      */
-    public function addValidator(string $ruleName, Rule $rule): void
+    public function addValidator(string $ruleName, Rule $rule)
     {
         if (!$this->allowRuleOverride && array_key_exists($ruleName, $this->validators)) {
             throw new RuleQuashException(
@@ -207,7 +207,7 @@ class Validator
      * @param boolean $status
      * @return void
      */
-    public function allowRuleOverride(bool $status = false): void
+    public function allowRuleOverride(bool $status = false)
     {
         $this->allowRuleOverride = $status;
     }
@@ -218,7 +218,7 @@ class Validator
      * @param boolean $useHumanizedKeys
      * @return void
      */
-    public function setUseHumanizedKeys(bool $useHumanizedKeys = true): void
+    public function setUseHumanizedKeys(bool $useHumanizedKeys = true)
     {
         $this->useHumanizedKeys = $useHumanizedKeys;
     }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -56,7 +56,7 @@ class Validator
      * Register or override existing validator
      *
      * @param mixed $key
-     * @param Rule $rule
+     * @param Rakit\Validation\Rule $rule
      * @return void
      */
     public function setValidator(string $key, Rule $rule)
@@ -187,7 +187,7 @@ class Validator
      * Given $ruleName and $rule to add new validator
      *
      * @param string $ruleName
-     * @param Rule $rule
+     * @param Rakit\Validation\Rule $rule
      * @return void
      */
     public function addValidator(string $ruleName, Rule $rule)

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -5,54 +5,113 @@ namespace Rakit\Validation;
 class Validator
 {
 
+    /** @var array */
     protected $messages = [];
 
+    /** @var array */
     protected $validators = [];
 
+    /** @var bool */
     protected $allowRuleOverride = false;
 
+    /** @var bool */
     protected $useHumanizedKeys = true;
 
+    /**
+     * Constructor
+     *
+     * @param array $messages
+     * @return void
+     */
     public function __construct(array $messages = [])
     {
         $this->messages = $messages;
         $this->registerBaseValidators();
     }
 
+    /**
+     * Given $key and $message to set message
+     *
+     * @param mixed $key
+     * @param mixed $message
+     * @return void
+     */
     public function setMessage($key, $message)
     {
         return $this->messages[$key] = $message;
     }
 
+    /**
+     * Given $messages and set multiple messages
+     *
+     * @param array $messages
+     * @return void
+     */
     public function setMessages($messages)
     {
         $this->messages = array_merge($this->messages, $messages);
     }
 
+    /**
+     * Given $key and $rule to ser validator
+     *
+     * @param mixed $key
+     * @param Rule $rule
+     * @return void
+     */
     public function setValidator($key, Rule $rule)
     {
         $this->validators[$key] = $rule;
         $rule->setKey($key);
     }
 
+    /**
+     * Given $key to get validator
+     *
+     * @param mixed $key
+     * @return mixed
+     */
     public function getValidator($key)
     {
         return isset($this->validators[$key])? $this->validators[$key] : null;
     }
 
-    public function validate(array $inputs, array $rules, array $messages = array())
+    /**
+     * Validate $inputs
+     *
+     * @param array $inputs
+     * @param array $rules
+     * @param array $messages
+     * @return Validation
+     */
+    public function validate(array $inputs, array $rules, array $messages = [])
     {
         $validation = $this->make($inputs, $rules, $messages);
         $validation->validate();
         return $validation;
     }
 
-    public function make(array $inputs, array $rules, array $messages = array())
+    /**
+     * Given $inputs, $rules and $messages to make the Validation class instance
+     *
+     * @param array $inputs
+     * @param array $rules
+     * @param array $messages
+     * @return Validation
+     */
+    public function make(array $inputs, array $rules, array $messages = [])
     {
         $messages = array_merge($this->messages, $messages);
         return new Validation($this, $inputs, $rules, $messages);
     }
 
+    /**
+     * magic invoke method
+     *
+     * @param mixed $rule
+     * @return mixed
+     * @throws RuleNotFoundException
+     */
     public function __invoke($rule)
     {
         $args = func_get_args();
@@ -69,6 +128,11 @@ class Validator
         return $clonedValidator;
     }
 
+    /**
+     * Initialize base validators array
+     *
+     * @return void
+     */
     protected function registerBaseValidators()
     {
         $baseValidator = [
@@ -119,6 +183,13 @@ class Validator
         }
     }
 
+    /**
+     * Given $ruleName and $rule to sdd new validator
+     *
+     * @param mixed $ruleName
+     * @param Rule $rule
+     * @return void
+     */
     public function addValidator($ruleName, Rule $rule)
     {
         if (!$this->allowRuleOverride && array_key_exists($ruleName, $this->validators)) {
@@ -130,16 +201,33 @@ class Validator
         $this->setValidator($ruleName, $rule);
     }
 
+    /**
+     * Set rule can allow to be overrided
+     *
+     * @param boolean $status
+     * @return void
+     */
     public function allowRuleOverride($status = false)
     {
         $this->allowRuleOverride = $status;
     }
 
+    /**
+     * Set this can use humanize keys
+     *
+     * @param boolean $useHumanizedKeys
+     * @return void
+     */
     public function setUseHumanizedKeys($useHumanizedKeys = true)
     {
         $this->useHumanizedKeys = $useHumanizedKeys;
     }
 
+    /**
+     * Get $this->useHumanizedKeys value
+     *
+     * @return void
+     */
     public function getUseHumanizedKeys()
     {
         return $this->useHumanizedKeys;


### PR DESCRIPTION
# Changed log
- It's related to issue #63.
- I use the `PHPDoc` style and internal PHP type hints to complete the type hints for all codes in `src` folder.

I'm not sure that these type hints or annotation comments are set the correct type hints/comments.

@emsifa, please check that and write down some comments/request changes.

Thanks.