### PR TITLE
Change implementation 'default' rule, and support multiple file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,8 +440,8 @@ The field under validation must be present and not empty only when all of the ot
 
 <details><summary><strong>uploaded_file</strong>:min_size,max_size,extension_a,extension_b,...</summary>
 
-This rule will validate `$_FILES` data, but not for multiple uploaded files. 
-Field under this rule must be following rules below to be valid:
+This rule will validate data from `$_FILES`. 
+Field under this rule must be follows rules below to be valid:
 
 * `$_FILES['key']['error']` must be `UPLOAD_ERR_OK` or `UPLOAD_ERR_NO_FILE`. For `UPLOAD_ERR_NO_FILE` you can validate it with `required` rule. 
 * If min size is given, uploaded file size **MUST NOT** be lower than min size.
@@ -455,6 +455,56 @@ Here are some example definitions and explanations:
 * `uploaded_file:0,1M`: uploaded file size must be between 0 - 1 MB, but uploaded file is optional.
 * `required|uploaded_file:0,1M,png,jpeg`: uploaded file size must be between 0 - 1MB and mime types must be `image/jpeg` or `image/png`.
 
+Optionally, if you want to have separate error message between size and type validation.
+You can use `mimes` rule to validate file types, and `min`, `max`, or `between` to validate it's size.
+
+For multiple file upload, PHP will give you undesirable array `$_FILES` structure ([here](http://php.net/manual/en/features.file-upload.multiple.php#53240) is the topic). So we make `uploaded_file` rule to automatically resolve your `$_FILES` value to be well-organized array structure. That means, you cannot only use `min`, `max`, `between`, or `mimes` rules to validate multiple file upload. You should put `uploaded_file` just to resolve it's value and make sure that value is correct uploaded file value.
+
+For example if you have input files like this:
+
+```html
+<input type="file" name="photos[]"/>
+<input type="file" name="photos[]"/>
+<input type="file" name="photos[]"/>
+```
+
+You can  simply validate it like this:
+
+```php
+$validation = $validator->validate($_FILES, [
+    'photos.*' => 'uploaded_file:0,2M,jpeg,png'
+]);
+
+// or
+
+$validation = $validator->validate($_FILES, [
+    'photos.*' => 'uploaded_file|max:2M|mimes:jpeg,png'
+]);
+```
+
+Or if you have input files like this:
+
+```html
+<input type="file" name="images[profile]"/>
+<input type="file" name="images[cover]"/>
+```
+
+You can validate it like this:
+
+```php
+$validation = $validator->validate($_FILES, [
+    'images.*' => 'uploaded_file|max:2M|mimes:jpeg,png',
+]);
+
+// or
+
+$validation = $validator->validate($_FILES, [
+    'images.profile' => 'uploaded_file|max:2M|mimes:jpeg,png',
+    'images.cover' => 'uploaded_file|max:5M|mimes:jpeg,png',
+]);
+```
+
+Now when you use `getValidData()` or `getInvalidData()` you will get well array structure just like single file upload.
 
 </details>
 

--- a/src/Rules/Defaults.php
+++ b/src/Rules/Defaults.php
@@ -3,8 +3,9 @@
 namespace Rakit\Validation\Rules;
 
 use Rakit\Validation\Rule;
+use Rakit\Validation\Rules\Interfaces\ModifyValue;
 
-class Defaults extends Rule
+class Defaults extends Rule implements ModifyValue
 {
 
     /** @var string */
@@ -25,5 +26,25 @@ class Defaults extends Rule
 
         $default = $this->parameter('default');
         return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function modifyValue($value)
+    {
+        return $this->isEmptyValue($value) ? $this->parameter('default') : $value;
+    }
+
+    /**
+     * Check $value is empty value
+     *
+     * @param mixed $value
+     * @return boolean
+     */
+    protected function isEmptyValue($value): bool
+    {
+        $requiredValidator = new Required;
+        return false === $requiredValidator->check($value, []);
     }
 }

--- a/src/Rules/Interfaces/BeforeValidate.php
+++ b/src/Rules/Interfaces/BeforeValidate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rakit\Validation\Rules\Interfaces;
+
+interface BeforeValidate
+{
+    /**
+     * Before validate hook
+     *
+     * @return void
+     */
+    public function beforeValidate();
+}

--- a/src/Rules/Interfaces/ModifyValue.php
+++ b/src/Rules/Interfaces/ModifyValue.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rakit\Validation\Rules\Interfaces;
+
+interface ModifyValue
+{
+    /**
+     * Modify given value
+     * so in current and next rules returned value will be used
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    public function modifyValue($value);
+}

--- a/src/Rules/Traits/FileTrait.php
+++ b/src/Rules/Traits/FileTrait.php
@@ -3,6 +3,7 @@
 namespace Rakit\Validation\Rules\Traits;
 
 use InvalidArgumentException;
+use Rakit\Validation\Helper;
 
 trait FileTrait
 {
@@ -38,5 +39,48 @@ trait FileTrait
     public function isUploadedFile($value): bool
     {
         return $this->isValueFromUploadedFiles($value) && is_uploaded_file($value['tmp_name']);
+    }
+
+    /**
+     * Resolve uploaded file value
+     *
+     * @param  mixed $value
+     * @return array|null
+     */
+    public function resolveUploadedFileValue($value)
+    {
+        if (!$this->isValueFromUploadedFiles($value)) {
+            return null;
+        }
+
+        // Here $value should be an array:
+        // [
+        //      'name'      => string|array,
+        //      'type'      => string|array,
+        //      'size'      => int|array,
+        //      'tmp_name'  => string|array,
+        //      'error'     => string|array,
+        // ]
+
+        // Flatten $value to it's array dot format,
+        // so our array must be something like:
+        // ['name' => string, 'type' => string, 'size' => int, ...]
+        // or for multiple values:
+        // ['name.0' => string, 'name.1' => string, 'type.0' => string, 'type.1' => string, ...]
+        // or for nested array:
+        // ['name.foo.bar' => string, 'name.foo.baz' => string, 'type.foo.bar' => string, 'type.foo.baz' => string, ...]
+        $arrayDots = Helper::arrayDot($value);
+
+        $results = [];
+        foreach ($arrayDots as $key => $val) {
+            // Move first key to last key
+            // name.foo.bar -> foo.bar.name
+            $splits = explode(".", $key);
+            $firstKey = array_shift($splits);
+            $key = count($splits) ? implode(".", $splits) . ".{$firstKey}" : $firstKey;
+
+            Helper::arraySet($results, $key, $val);
+        }
+        return $results;
     }
 }

--- a/tests/Rules/UploadedFileTest.php
+++ b/tests/Rules/UploadedFileTest.php
@@ -133,7 +133,6 @@ class UploadedFileTest extends TestCase
 
     public function testFileTypes()
     {
-
         $rule = $this->getMockBuilder(UploadedFile::class)
             ->setMethods(['isUploadedFile'])
             ->getMock();


### PR DESCRIPTION
* [out of context] Added `Rakit\Validation\Rules\Interfaces\ModifyValue` to modify attribute value while validating it's attribute.
* [out of context] `Default` rule implements `Rakit\Validation\Rules\Interfaces\ModifyValue` to modify it's atttribute value. 
* Added `Rakit\Validation\Rules\Interfaces\BeforeValidate` so `Rakit\Validation\Rule` classes are able to do some preparation before validation running. 
* `Rakit\Validation\Rules\UploadedFile` class implements `Rakit\Validation\Rules\Interfaces\BeforeValidate` to resolve multiple file upload values before validation running.

Here are the examples (embedded from `ValidatorTest.php`):

* Indexed multiple file upload: https://github.com/rakit/validation/blob/97779a45bc39b17b38bf956463faffbab600a0b8/tests/ValidatorTest.php#L142-L201
* Key based multiple file upload: https://github.com/rakit/validation/blob/97779a45bc39b17b38bf956463faffbab600a0b8/tests/ValidatorTest.php#L203-L263
* Combined: https://github.com/rakit/validation/blob/97779a45bc39b17b38bf956463faffbab600a0b8/tests/ValidatorTest.php#L265-L394