### PR TITLE
Wrong property name in new Rule Readme's unique example

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ class UniqueRule extends Rule
 {
     protected $message = ":attribute :value has been used";
     
-    protected $fillable_params = ['table', 'column', 'except'];
+    protected $fillableParams = ['table', 'column', 'except'];
     
     protected $pdo;
     


### PR DESCRIPTION
Testing your library I detected that the Readme's example to generate the new rule UniqueRule has a bug. In the example exists the property $filleable_params, but this property has an incorrect name and generate the following error:
`Fatal error: Uncaught Rakit\Validation\MissingRequiredParameterException: Missing required parameter 'table' on rule 'unique' in /var/www/html/vendor/rakit/validation/src/Rule.php on line 228`

The solution is change the property's name to the fillableParams.