### PR TITLE
TypeError in arrayUnset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_script:
   - ./vendor/bin/phpcs -n --standard=PSR2 src/ tests/
 
 script:
-  - phpunit --coverage-text
+  - ./vendor/bin/phpunit --coverage-text

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -165,7 +165,7 @@ class Helper
      * @param  string|array $key
      * @return mixed
      */
-    public static function arrayUnset(&$target, $key): array
+    public static function arrayUnset(&$target, $key)
     {
         if (!is_array($target)) {
             return $target;

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -803,6 +803,16 @@ class ValidatorTest extends TestCase
         $this->assertNull($errors->first('user.name:required'));
     }
 
+    public function testEmptyArrayAssocValidation()
+    {
+        $validation = $this->validator->validate([], [
+            'user'=> 'required',
+            'user.email' => 'email',
+        ]);
+
+        $this->assertFalse($validation->passes());
+    }
+
     public function testArrayValidation()
     {
         $validation = $this->validator->validate([


### PR DESCRIPTION
Hello, 

I'm trying to run the following validation, to validate that the array 'user' as at least one field (eg phone or email) and that the email is really an email: 

```php
$validation = $this->validator->validate([], [
     'user' => 'required',
     'user.email' => 'email',
]);
```

This produces a TypeError: 

```
TypeError: Return value of Rakit\Validation\Helper::arrayUnset() must be of the type array, null returned

validation/src/Helper.php:171
validation/src/Helper.php:181
validation/src/Validation.php:694
validation/src/Validation.php:168
validation/src/Validation.php:105
validation/src/Validator.php:68
validation/tests/ValidatorTest.php:809
```

This is due to an invalid typehint in the method `Helper::arrayUnset`. 

So there is a workaround for that: 
```php
$validation = $this->validator->validate([], [
     'user.email' => 'email|required_without:user.phone',
     'user.phone' => 'required_without:user.email',
]);
```
But the most fields you have, the most complex the array grows. 