### PR TITLE
Feat/asterisk at root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_script:
   - ./vendor/bin/phpcs -n --standard=PSR2 src/ tests/
 
 script:
-  - phpunit --coverage-text
+  - ./vendor/bin/phpunit --coverage-text

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -58,12 +58,12 @@ class Helper
      * Get an item from an array using "dot" notation.
      * Adapted from: https://github.com/illuminate/support/blob/v5.3.23/Arr.php#L246
      *
-     * @param  array  $array
-     * @param  string $key
-     * @param  mixed  $default
+     * @param  array       $array
+     * @param  string|null $key
+     * @param  mixed       $default
      * @return mixed
      */
-    public static function arrayGet(array $array, string $key, $default = null)
+    public static function arrayGet(array $array, $key, $default = null)
     {
         if (is_null($key)) {
             return $array;
@@ -111,14 +111,21 @@ class Helper
      * Set an item on an array or object using dot notation.
      * Adapted from: https://github.com/illuminate/support/blob/v5.3.23/helpers.php#L437
      *
-     * @param  mixed        $target
-     * @param  string|array $key
-     * @param  mixed        $value
-     * @param  bool         $overwrite
+     * @param mixed             $target
+     * @param string|array|null $key
+     * @param mixed             $value
+     * @param bool              $overwrite
      * @return mixed
      */
     public static function arraySet(&$target, $key, $value, $overwrite = true): array
     {
+        if (is_null($key)) {
+            if ($overwrite) {
+                return $target = array_merge($target, $value);
+            }
+            return $target = array_merge($value, $target);
+        }
+
         $segments = is_array($key) ? $key : explode('.', $key);
 
         if (($segment = array_shift($segments)) === '*') {

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -282,9 +282,9 @@ class Validation
      * Allows us to not spin through all of the flattened data for some operations.
      *
      * @param  string  $attributeKey
-     * @return string
+     * @return string|null null when root wildcard
      */
-    protected function getLeadingExplicitAttributePath(string $attributeKey): string
+    protected function getLeadingExplicitAttributePath(string $attributeKey)
     {
         return rtrim(explode('*', $attributeKey)[0], '.') ?: null;
     }
@@ -295,10 +295,10 @@ class Validation
      *
      * Used to extract a sub-section of the data for faster iteration.
      *
-     * @param  string  $attributeKey
+     * @param  string|null $attributeKey
      * @return array
      */
-    protected function extractDataFromPath(string $attributeKey): array
+    protected function extractDataFromPath($attributeKey): array
     {
         $results = [];
 


### PR DESCRIPTION
Fix for https://github.com/rakit/validation/issues/60

This adds the possibility of setting having a root `*` attribute key. 

Rules are follow are now possible: 

```php
$validator->validate([
    'a' => 1,
    'b' => 2,
    'c' => '3',
    'd' => 'four'
], [
    '*' => 'integer'
]);
```
```php
$validator->validate([1, 2, '3', 'four'], [ '*' => 'integer' ]);
```
```php
$validator->validate([
    ['A' => 'aaa', 'B' => 25 ],
    ['A' => 'bbb', 'B' => 'four' ],
    ['A' => 'bbb' ],
], [ 
    '*.A' => 'required|string',
    '*.B' => 'required|integer'
]);
```