### PR TITLE
Fixing Type in phpdoc params

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -14,13 +14,13 @@ class Attribute
     /** @var string|null */
     protected $alias;
 
-    /** @var Rakit\Validation\Validation */
+    /** @var \Rakit\Validation\Validation */
     protected $validation;
 
     /** @var bool */
     protected $required = false;
 
-    /** @var Rakit\Validation\Validation|null */
+    /** @var \Rakit\Validation\Validation|null */
     protected $primaryAttribute = null;
 
     /** @var array */
@@ -32,7 +32,7 @@ class Attribute
     /**
      * Constructor
      *
-     * @param Rakit\Validation\Validation  $validation
+     * @param \Rakit\Validation\Validation  $validation
      * @param string      $key
      * @param string|null $alias
      * @param array       $rules
@@ -55,7 +55,7 @@ class Attribute
     /**
      * Set the primary attribute
      *
-     * @param Rakit\Validation\Attribute $primaryAttribute
+     * @param \Rakit\Validation\Attribute $primaryAttribute
      * @return void
      */
     public function setPrimaryAttribute(Attribute $primaryAttribute)
@@ -77,7 +77,7 @@ class Attribute
     /**
      * Get primary attributes
      *
-     * @return Rakit\Validation\Attribute|null
+     * @return \Rakit\Validation\Attribute|null
      */
     public function getPrimaryAttribute()
     {
@@ -101,7 +101,7 @@ class Attribute
     /**
      * Add other attributes
      *
-     * @param Rakit\Validation\Attribute $otherAttribute
+     * @param \Rakit\Validation\Attribute $otherAttribute
      * @return void
      */
     public function addOtherAttribute(Attribute $otherAttribute)
@@ -122,7 +122,7 @@ class Attribute
     /**
      * Add rule
      *
-     * @param Rakit\Validation\Rule $rule
+     * @param \Rakit\Validation\Rule $rule
      * @return void
      */
     public function addRule(Rule $rule)

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -9,10 +9,10 @@ abstract class Rule
     /** @var string */
     protected $key;
 
-    /** @var Rakit\Validation\Attribute|null */
+    /** @var \Rakit\Validation\Attribute|null */
     protected $attribute;
 
-    /** @var Rakit\Validation\Validation|null */
+    /** @var \Rakit\Validation\Validation|null */
     protected $validation;
 
     /** @var bool */
@@ -35,7 +35,7 @@ abstract class Rule
     /**
      * Set Validation class instance
      *
-     * @param Rakit\Validation\Validation $validation
+     * @param \Rakit\Validation\Validation $validation
      * @return void
      */
     public function setValidation(Validation $validation)
@@ -67,7 +67,7 @@ abstract class Rule
     /**
      * Set attribute
      *
-     * @param Rakit\Validation\Attribute $attribute
+     * @param \Rakit\Validation\Attribute $attribute
      * @return void
      */
     public function setAttribute(Attribute $attribute)
@@ -78,7 +78,7 @@ abstract class Rule
     /**
      * Get attribute
      *
-     * @return Rakit\Validation\Attribute|null
+     * @return \Rakit\Validation\Attribute|null
      */
     public function getAttribute()
     {
@@ -99,7 +99,7 @@ abstract class Rule
      * Set params
      *
      * @param array $params
-     * @return Rakit\Validation\Rule
+     * @return \Rakit\Validation\Rule
      */
     public function setParameters(array $params): Rule
     {
@@ -112,7 +112,7 @@ abstract class Rule
      *
      * @param string $key
      * @param mixed $value
-     * @return Rakit\Validation\Rule
+     * @return \Rakit\Validation\Rule
      */
     public function setParameter(string $key, $value): Rule
     {
@@ -124,7 +124,7 @@ abstract class Rule
      * Fill $params to $this->params
      *
      * @param array $params
-     * @return Rakit\Validation\Rule
+     * @return \Rakit\Validation\Rule
      */
     public function fillParameters(array $params): Rule
     {
@@ -184,7 +184,7 @@ abstract class Rule
      * Just alias of setMessage
      *
      * @param string $message
-     * @return Rakit\Validation\Rule
+     * @return \Rakit\Validation\Rule
      */
     public function message(string $message): Rule
     {
@@ -195,7 +195,7 @@ abstract class Rule
      * Set message
      *
      * @param string $message
-     * @return Rakit\Validation\Rule
+     * @return \Rakit\Validation\Rule
      */
     public function setMessage(string $message): Rule
     {
@@ -218,7 +218,7 @@ abstract class Rule
      *
      * @param array $params
      * @return void
-     * @throws Rakit\Validation\MissingRequiredParameterException
+     * @throws \Rakit\Validation\MissingRequiredParameterException
      */
     protected function requireParameters(array $params)
     {

--- a/src/Rules/After.php
+++ b/src/Rules/After.php
@@ -20,7 +20,7 @@ class After extends Rule
      *
      * @param mixed $value
      * @return bool
-     * @throws Exception
+     * @throws \Exception
      */
     public function check($value): bool
     {

--- a/src/Rules/Before.php
+++ b/src/Rules/Before.php
@@ -19,7 +19,7 @@ class Before extends Rule
      *
      * @param mixed $value
      * @return bool
-     * @throws Exception
+     * @throws \Exception
      */
     public function check($value): bool
     {

--- a/src/Rules/Callback.php
+++ b/src/Rules/Callback.php
@@ -31,7 +31,7 @@ class Callback extends Rule
      *
      * @param mixed $value
      * @return bool
-     * @throws Exception
+     * @throws \Exception
      */
     public function check($value): bool
     {

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -38,7 +38,7 @@ class Validation
     /**
      * Constructor
      *
-     * @param Rakit\Validation\Validator $validator
+     * @param \Rakit\Validation\Validator $validator
      * @param array $inputs
      * @param array $rules
      * @param array $messages
@@ -77,7 +77,7 @@ class Validation
      * Get attribute by key
      *
      * @param string $attributeKey
-     * @return null|Rakit\Validation\Attribute
+     * @return null|\Rakit\Validation\Attribute
      */
     public function getAttribute(string $attributeKey)
     {
@@ -112,7 +112,7 @@ class Validation
     /**
      * Get ErrorBag instance
      *
-     * @return Rakit\Validation\ErrorBag
+     * @return \Rakit\Validation\ErrorBag
      */
     public function errors(): ErrorBag
     {
@@ -122,7 +122,7 @@ class Validation
     /**
      * Validate attribute
      *
-     * @param Rakit\Validation\Attribute $attribute
+     * @param \Rakit\Validation\Attribute $attribute
      * @return void
      */
     protected function validateAttribute(Attribute $attribute)
@@ -175,7 +175,7 @@ class Validation
     /**
      * Check whether given $attribute is array attribute
      *
-     * @param Rakit\Validation\Attribute $attribute
+     * @param \Rakit\Validation\Attribute $attribute
      * @return bool
      */
     protected function isArrayAttribute(Attribute $attribute): bool
@@ -187,7 +187,7 @@ class Validation
     /**
      * Parse array attribute into it's child attributes
      *
-     * @param Rakit\Validation\Attribute $attribute
+     * @param \Rakit\Validation\Attribute $attribute
      * @return array
      */
     protected function parseArrayAttribute(Attribute $attribute): array
@@ -317,9 +317,9 @@ class Validation
     /**
      * Add error to the $this->errors
      *
-     * @param Rakit\Validation\Attribute $attribute
+     * @param \Rakit\Validation\Attribute $attribute
      * @param mixed $value
-     * @param Rakit\Validation\Rule $ruleValidator
+     * @param \Rakit\Validation\Rule $ruleValidator
      * @return void
      */
     protected function addError(Attribute $attribute, $value, Rule $ruleValidator)
@@ -345,8 +345,8 @@ class Validation
     /**
      * Check the rule is optional
      *
-     * @param Rakit\Validation\Attribute $attribute
-     * @param Rakit\Validation\Rule $rule
+     * @param \Rakit\Validation\Attribute $attribute
+     * @param \Rakit\Validation\Rule $rule
      * @return bool
      */
     protected function ruleIsOptional(Attribute $attribute, Rule $rule): bool
@@ -359,7 +359,7 @@ class Validation
     /**
      * Resolve attribute name
      *
-     * @param Rakit\Validation\Attribute $attribute
+     * @param \Rakit\Validation\Attribute $attribute
      * @return string
      */
     protected function resolveAttributeName(Attribute $attribute): string
@@ -379,9 +379,9 @@ class Validation
     /**
      * Resolve message
      *
-     * @param Rakit\Validation\Attribute $attribute
+     * @param \Rakit\Validation\Attribute $attribute
      * @param mixed $value
-     * @param Rakit\Validation\Rule $validator
+     * @param \Rakit\Validation\Rule $validator
      * @return mixed
      */
     protected function resolveMessage(Attribute $attribute, $value, Rule $validator): string
@@ -614,7 +614,7 @@ class Validation
     /**
      * Get Validator class instance
      *
-     * @return Rakit\Validation\Validator
+     * @return \Rakit\Validation\Validator
      */
     public function getValidator(): Validator
     {
@@ -657,7 +657,7 @@ class Validation
     /**
      * Set valid data
      *
-     * @param Rakit\Validation\Attribute $attribute
+     * @param \Rakit\Validation\Attribute $attribute
      * @param mixed $value
      * @return void
      */
@@ -685,7 +685,7 @@ class Validation
     /**
      * Set invalid data
      *
-     * @param Rakit\Validation\Attribute $attribute
+     * @param \Rakit\Validation\Attribute $attribute
      * @param mixed $value
      * @return void
      */

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -6,7 +6,7 @@ class Validator
 {
     use Traits\TranslationsTrait, Traits\MessagesTrait;
 
-    /** @var translations */
+    /** @var array */
     protected $translations = [];
 
     /** @var array */
@@ -34,7 +34,7 @@ class Validator
      * Register or override existing validator
      *
      * @param mixed $key
-     * @param Rakit\Validation\Rule $rule
+     * @param \Rakit\Validation\Rule $rule
      * @return void
      */
     public function setValidator(string $key, Rule $rule)
@@ -171,7 +171,7 @@ class Validator
      * Given $ruleName and $rule to add new validator
      *
      * @param string $ruleName
-     * @param Rakit\Validation\Rule $rule
+     * @param \Rakit\Validation\Rule $rule
      * @return void
      */
     public function addValidator(string $ruleName, Rule $rule)

--- a/tests/Rules/AfterTest.php
+++ b/tests/Rules/AfterTest.php
@@ -31,7 +31,7 @@ class AfterTest extends TestCase
 
     /**
      * @dataProvider getInvalidDates
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testANonWellFormedDateCannotBeValidated($date)
     {
@@ -39,7 +39,7 @@ class AfterTest extends TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testUserProvidedParamCannotBeValidatedBecauseItIsInvalid()
     {

--- a/tests/Rules/BeforeTest.php
+++ b/tests/Rules/BeforeTest.php
@@ -45,7 +45,7 @@ class BeforeTest extends TestCase
 
     /**
      * @dataProvider getInvalidDates
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testANonWellFormedDateCannotBeValidated($date)
     {
@@ -82,7 +82,7 @@ class BeforeTest extends TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testUserProvidedParamCannotBeValidatedBecauseItIsInvalid()
     {

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -619,7 +619,7 @@ class ValidatorTest extends TestCase
     }
 
     /**
-     * @expectedException Rakit\Validation\RuleQuashException
+     * @expectedException \Rakit\Validation\RuleQuashException
      */
     public function testInternalValidationRuleCannotBeOverridden()
     {
@@ -813,7 +813,7 @@ class ValidatorTest extends TestCase
 
         $this->assertFalse($validation->passes());
     }
-  
+
     /**
      * Test root asterisk validation.
      *


### PR DESCRIPTION
The Type used for the phpdocs elements is incorrect. 

According to the [phpdoc documentation](https://docs.phpdoc.org/references/phpdoc/types.html#valid-class-name), the type should be: 

> A valid class name seen from the context where this type is mentioned. Thus this may be either a Fully Qualified Class Name (FQCN) or if present in a namespace a local name.

The missing `\` at the beginning of the FQCN is confusing a lot PhpStorm for instance. 

In this PR, I'm adding this missing backslash.