### PR TITLE
Improve assertion and testing classes autoloading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 before_script:
   - composer install

--- a/tests/Rules/AcceptedTest.php
+++ b/tests/Rules/AcceptedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Accepted;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/AfterTest.php
+++ b/tests/Rules/AfterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\After;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/AlphaDashTest.php
+++ b/tests/Rules/AlphaDashTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\AlphaDash;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/AlphaNumTest.php
+++ b/tests/Rules/AlphaNumTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\AlphaNum;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/AlphaSpacesTest.php
+++ b/tests/Rules/AlphaSpacesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\AlphaSpaces;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/AlphaTest.php
+++ b/tests/Rules/AlphaTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Alpha;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/BeforeTest.php
+++ b/tests/Rules/BeforeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Before;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/BetweenTest.php
+++ b/tests/Rules/BetweenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Between;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/BooleanTest.php
+++ b/tests/Rules/BooleanTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use PHPUnit\Framework\TestCase;
 use Rakit\Validation\Rules\Boolean;

--- a/tests/Rules/CallbackTest.php
+++ b/tests/Rules/CallbackTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Callback;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/DateTest.php
+++ b/tests/Rules/DateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Date;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/DefaultsTest.php
+++ b/tests/Rules/DefaultsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Defaults;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/DigitsBetweenTest.php
+++ b/tests/Rules/DigitsBetweenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\DigitsBetween;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/DigitsTest.php
+++ b/tests/Rules/DigitsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Digits;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/EmailTest.php
+++ b/tests/Rules/EmailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Email;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/ExtensionTest.php
+++ b/tests/Rules/ExtensionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Extension;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/InTest.php
+++ b/tests/Rules/InTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\In;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/IntegerTest.php
+++ b/tests/Rules/IntegerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Integer;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/IpTest.php
+++ b/tests/Rules/IpTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Ip;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/Ipv4Test.php
+++ b/tests/Rules/Ipv4Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Ipv4;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/Ipv6Test.php
+++ b/tests/Rules/Ipv6Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Ipv6;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/JsonTest.php
+++ b/tests/Rules/JsonTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Json;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/LowercaseTest.php
+++ b/tests/Rules/LowercaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Lowercase;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/MaxTest.php
+++ b/tests/Rules/MaxTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Max;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/MimesTest.php
+++ b/tests/Rules/MimesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Mimes;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/MinTest.php
+++ b/tests/Rules/MinTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Min;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/NotInTest.php
+++ b/tests/Rules/NotInTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\NotIn;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/NumericTest.php
+++ b/tests/Rules/NumericTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Numeric;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/RegexTest.php
+++ b/tests/Rules/RegexTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Regex;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/RequiredTest.php
+++ b/tests/Rules/RequiredTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Required;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/TypeArrayTest.php
+++ b/tests/Rules/TypeArrayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\TypeArray;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/UploadedFileTest.php
+++ b/tests/Rules/UploadedFileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\UploadedFile;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/UppercaseTest.php
+++ b/tests/Rules/UppercaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Uppercase;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/UrlTest.php
+++ b/tests/Rules/UrlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rakit\Validation\Tests;
+namespace Rakit\Validation\Tests\Rules;
 
 use Rakit\Validation\Rules\Url;
 use PHPUnit\Framework\TestCase;

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1313,7 +1313,7 @@ class ValidatorTest extends TestCase
         ], $validData);
 
         $stuffs = $validData['stuffs'];
-        $this->assertFalse(isset($stuffs['three']));
+        $this->assertArrayNotHasKey('three', $stuffs);
     }
 
     public function testGetInvalidData()
@@ -1366,8 +1366,8 @@ class ValidatorTest extends TestCase
         ], $invalidData);
 
         $stuffs = $invalidData['stuffs'];
-        $this->assertFalse(isset($stuffs['one']));
-        $this->assertFalse(isset($stuffs['two']));
+        $this->assertArrayNotHasKey('one', $stuffs);
+        $this->assertArrayNotHasKey('two', $stuffs);
     }
 
     public function testRuleInInvalidMessages()


### PR DESCRIPTION
# Changed log

- Using the `assertArrayNotHasKey` to assert expected array has the key.
- Add the `php-7.3` and `php-7.4` version tests during Travis CI building.
- Using the `Rakit\Validation\Tests\Rules;` namespace for classes on `tests/Rules` folder and it can be compatible with the `PSR-4` autoloader.