### PR TITLE
Allowing users to add commas in parameters.

### DIFF
--- a/src/Validation.php
+++ b/src/Validation.php
@@ -519,7 +519,8 @@ class Validation
         $exp = explode(':', $rule, 2);
         $rulename = $exp[0];
         if ($rulename !== 'regex') {
-            $params = isset($exp[1])? explode(',', $exp[1]) : [];
+            $params = isset($exp[1]) ?
+                str_replace("\,", ",", preg_split('~(?<!\\\)' . preg_quote(",", '~') . '~', $exp[1])) : [];
         } else {
             $params = [$exp[1]];
         }

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -68,6 +68,13 @@ class ValidationTest extends TestCase
                     ['/^([a-zA-Z\,]*)$/'],
                 ],
             ],
+            [
+                "in:a,b\,c,d\,e",
+                [
+                    'in',
+                    ['a','b,c','d,e']
+                ]
+            ]
         ];
     }
 }


### PR DESCRIPTION
This PR will allowing users to add commas in parameters. Add a backslash before the comma to escape.

