### PR TITLE
Update Date.php

### DIFF
--- a/src/Rules/Date.php
+++ b/src/Rules/Date.php
@@ -29,6 +29,6 @@ class Date extends Rule
         $this->requireParameters($this->fillableParams);
 
         $format = $this->parameter('format');
-        return date_create_from_format($format, $value) !== false;
+        return date_create_from_format($format, $value ?? '') !== false;
     }
 }


### PR DESCRIPTION
In a recent project, we've experienced issues using the Date rule filter due to a depracated warning caused by the Date.php rule.

```
Deprecated...  date_create_from_format(): Passing null to parameter #2 ($datetime) of type string is deprecated in .../vendor/rakit/validation/src/Rules/Date.php
```

Proposed fix: Default $datetime argument ($value) to an empty string over `null` to prevent a deprecation warning. I am unsure whether this approach is up to the standards of this code base but it was a viable fix to our problem.