### PR TITLE
Include explanatory message in thrown exception

### DIFF
--- a/src/Validation.php
+++ b/src/Validation.php
@@ -499,7 +499,7 @@ class Validation
             } else {
                 $ruleName = is_object($rule) ? get_class($rule) : gettype($rule);
                 $message = "Rule must be a string, Closure or '".Rule::class."' instance. ".$ruleName." given";
-                throw new \Exception();
+                throw new \Exception($message);
             }
 
             $resolvedRules[] = $validator;


### PR DESCRIPTION
The exception had no message and was required to  explore the source code to understand the reason. The variable holding the message was there, but unused.